### PR TITLE
updated set image for changing to nginx:1.7.1

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -163,7 +163,7 @@ kubectl run nginx --image=nginx --restart=Never --port=80
 <p>
 
 ```bash
-# kubectl set image POD_NAME CONTAINER_NAME=IMAGE_NAME:TAG
+# kubectl set image POD/POD_NAME CONTAINER_NAME=IMAGE_NAME:TAG
 kubectl set image pod/nginx nginx=nginx:1.7.1
 kubectl describe po nginx # you will see an event 'Container will be killed and recreated'
 kubectl get po nginx -w # watch it


### PR DESCRIPTION

possibly a newer version of k8s requires specificity on type of object for updating the image. i couldn't get it to work with the current example.

my kubectl client and server version: v1.12

updated based on documentation from `kubectl set images --help`

```
Examples:
  # Set a deployment's nginx container image to 'nginx:1.9.1', and its busybox container image to 'busybox'.
  kubectl set image deployment/nginx busybox=busybox nginx=nginx:1.9.1
```