### PR TITLE
Update from GB to Gi

### DIFF
--- a/g.state.md
+++ b/g.state.md
@@ -81,7 +81,7 @@ kubectl delete po busybox
 </details>
 
 
-### Create a PersistentVolume of 20GB, called 'myvolume'. Make it have accessMode of 'ReadWriteOnce' and 'ReadWriteMany', storageClassName 'normal', mounted on hostPath '/etc/foo'. Save it on pv.yaml, add it to the cluster. Show the PersistentVolumes that exist on the cluster 
+### Create a PersistentVolume of 10Gi, called 'myvolume'. Make it have accessMode of 'ReadWriteOnce' and 'ReadWriteMany', storageClassName 'normal', mounted on hostPath '/etc/foo'. Save it on pv.yaml, add it to the cluster. Show the PersistentVolumes that exist on the cluster
 
 <details><summary>show</summary>
 <p>
@@ -117,7 +117,7 @@ kubectl get pv
 </p>
 </details>
 
-### Create a PersistentVolumeClaim for this storage class, called mypvc, a request of 4GB and an accessMode of ReadWriteOnce and save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
+### Create a PersistentVolumeClaim for this storage class, called mypvc, a request of 4Gi and an accessMode of ReadWriteOnce and save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
Hi,

Thank you for the exercises. They helped me to pass the exam.

I find two small typos in `State persistence` section. Since Kubernetes uses `Gi` instead of `GB`, and the question answer doesn't match question, this PR updates the storage units.

Thanks,
Chenyuan

