### PR TITLE
Fix log check for job with counting pi digits

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -458,7 +458,7 @@ kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print
 ```bash
 kubectl get jobs -w # wait till 'SUCCESSFUL' is 1 (will take some time, perl image might be big)
 kubectl get po # get the pod name
-kubectl logs perl-**** # get the pi numbers
+kubectl logs pi-**** # get the pi numbers
 kubectl delete job pi
 ```
 


### PR DESCRIPTION
You reference `kubectl logs perl-**** # get the pi numbers` which references the container image name, but the pod name `pi-****`. A minor issue but could be confusing.