### PR TITLE
fix cp issue in kubectl version 14

### DIFF
--- a/g.state.md
+++ b/g.state.md
@@ -238,7 +238,7 @@ kubectl delete po busybox busybox2
 
 ```bash
 kubectl run busybox --image=busybox --restart=Never -- sleep 3600
-kubectl cp busybox:/etc/passwd . # kubectl cp command
+kubectl cp busybox:etc/passwd . # kubectl cp command
 cat passwd
 ```
 


### PR DESCRIPTION
For the question: Create a busybox pod with 'sleep 3600' as arguments. Copy '/etc/passwd' from the pod to your local folder

I got an error 'tar: removing leading '/' from member names', I used command 
`kubectl cp busybox:etc/passwd .` could work

kubectl version is
`Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.0", GitCommit:"641856db18352033a0d96dbc99153fa3b27298e5", GitTreeState:"clean", BuildDate:"2019-03-25T15:53:57Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.1", GitCommit:"b7394102d6ef778017f2ca4046abbaa23b88c290", GitTreeState:"clean", BuildDate:"2019-04-08T17:02:58Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"linux/amd64"}`