### PR TITLE
kubectl run update for new k8s vers

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -18,7 +18,7 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use 
 
 ```bash
 kubectl create namespace mynamespace
-kubectl run nginx --image=nginx --restart=Never -n mynamespace
+kubectl run nginx --image=nginx --generator=run-pod/v1 --restart=Never -n mynamespace
 ```
 
 </p>


### PR DESCRIPTION
```kubectl run nginx --image=nginx```
gives:
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
so it was fixed.