### PR TITLE
Removed deprecated --export flags

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -203,7 +203,7 @@ kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run -o yaml | sed 's
 <p>
 
 ```bash
-kubectl get deploy nginx --export -o yaml
+kubectl get deploy nginx -o yaml
 ```
 
 </p>
@@ -220,7 +220,7 @@ kubectl describe deploy nginx # you'll see the name of the replica set on the Ev
 kubectl get rs -l run=nginx # if you created deployment by 'run' command
 kubectl get rs -l app=nginx # if you created deployment by 'create' command
 # you could also just do kubectl get rs
-kubectl get rs nginx-7bf7478b77 --export -o yaml
+kubectl get rs nginx-7bf7478b77 -o yaml
 ```
 
 </p>
@@ -236,7 +236,7 @@ kubectl get po # get all the pods
 # OR you can find pods directly by:
 kubectl get po -l run=nginx # if you created deployment by 'run' command
 kubectl get po -l app=nginx # if you created deployment by 'create' command
-kubectl get po nginx-7bf7478b77-gjzp8 -o yaml --export
+kubectl get po nginx-7bf7478b77-gjzp8 -o yaml
 ```
 
 </p>


### PR DESCRIPTION
Flag --export has been deprecated, This flag is deprecated and will be removed in future. The alternative is a simple -o yaml and post-processing the yaml to remove undesired state information.