### PR TITLE
Simplify the wget call

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -204,10 +204,7 @@ kubectl get po nginx -o jsonpath='{.spec.containers[].image}{"\n"}'
 ```bash
 kubectl get po -o wide # get the IP, will be something like '10.1.1.131'
 # create a temp busybox pod
-kubectl run busybox --image=busybox --rm -it --restart=Never -- sh
-# run wget on specified IP:Port
-wget -O- 10.1.1.131:80
-exit
+kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- 10.1.1.131:80
 ```
 
 Alternatively you can also try a more advanced option:
@@ -216,10 +213,7 @@ Alternatively you can also try a more advanced option:
 # Get IP of the nginx pod
 NGINX_IP=$(kubectl get pod nginx -o jsonpath='{.status.podIP}')
 # create a temp busybox pod
-kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it --restart=Never -- sh
-# run wget on specified IP:Port
-wget -O- $NGINX_IP:80
-exit
+kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it --restart=Never -- wget -O- $NGINX_IP:80
 ``` 
 
 </p>


### PR DESCRIPTION
There is no reason to create a shell and run the wget inside of this shell, just call wget directly (since the shell is the command and wget will be an argument).