### PR TITLE
no need to expose port for probes

### DIFF
--- a/e.observability.md
+++ b/e.observability.md
@@ -96,7 +96,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --dry-run -o yaml --restart=Never > pod.yaml
+kubectl run nginx --image=nginx --dry-run -o yaml --restart=Never --port=80 > pod.yaml
 vi pod.yaml
 ```
 
@@ -114,6 +114,8 @@ spec:
     imagePullPolicy: IfNotPresent
     name: nginx
     resources: {}
+    ports:
+      - containerPort: 80
     readinessProbe: # declare the readiness probe
       httpGet: # add this line
         path: / #

--- a/e.observability.md
+++ b/e.observability.md
@@ -115,7 +115,7 @@ spec:
     name: nginx
     resources: {}
     ports:
-      - containerPort: 80 # Note: Readiness probes runs on the container during its whole lifecycle. Since nginx exposes 80, containerPort: 80 is not requierd for readiness to work.
+      - containerPort: 80 # Note: Readiness probes runs on the container during its whole lifecycle. Since nginx exposes 80, containerPort: 80 is not required for readiness to work.
     readinessProbe: # declare the readiness probe
       httpGet: # add this line
         path: / #

--- a/e.observability.md
+++ b/e.observability.md
@@ -115,7 +115,7 @@ spec:
     name: nginx
     resources: {}
     ports:
-      - containerPort: 80
+      - containerPort: 80 # Note: Readiness probes runs on the container during its whole lifecycle. Since nginx exposes 80, containerPort: 80 is not requierd for readiness to work.
     readinessProbe: # declare the readiness probe
       httpGet: # add this line
         path: / #

--- a/e.observability.md
+++ b/e.observability.md
@@ -96,7 +96,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --dry-run -o yaml --restart=Never --port=80 > pod.yaml
+kubectl run nginx --image=nginx --dry-run -o yaml --restart=Never > pod.yaml
 vi pod.yaml
 ```
 
@@ -114,8 +114,6 @@ spec:
     imagePullPolicy: IfNotPresent
     name: nginx
     resources: {}
-    ports:
-      - containerPort: 80
     readinessProbe: # declare the readiness probe
       httpGet: # add this line
         path: / #


### PR DESCRIPTION
I was doing the exercise and there is no need to expose the container port on kubernetes v1.15.1