### PR TITLE
Changed the question

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -440,7 +440,7 @@ kubectl delete hpa nginx
 
 ## Jobs
 
-### Create a job with image perl that runs default command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"
+### Create a job with image perl that runs the command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
Based on my understanding of the "**default**" command, it's the one that is set under `ENTRYPOINT` section of the container image. So, when you want to run that container with its default command, we should not override that default command while creating the container from that image. But here, when we use `-- perl ...` in either `create job` or `run` commands, it would override the default command of the job and does not just update the `args` of the default command. I hope this makes sense. Otherwise, feel free to reject the pull request.