### PR TITLE
Corrected the command

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -354,7 +354,7 @@ kubectl create secret generic mysecret2 --from-file=username
 
 ```bash
 kubectl get secret mysecret2 -o yaml --export
-echo YWRtaW4K | base64 -D # shows 'admin'
+echo YWRtaW4K | base64 -d # on MAC it is -D, which decodes the value and shows 'admin'
 ```
 
 Alternative:

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -354,7 +354,7 @@ kubectl create secret generic mysecret2 --from-file=username
 
 ```bash
 kubectl get secret mysecret2 -o yaml --export
-echo YWRtaW4K | base64 -d # shows 'admin'
+echo YWRtaW4K | base64 -D # shows 'admin'
 ```
 
 Alternative:


### PR DESCRIPTION
`-d` switch is not a valid option for `base64` command. It should be either `base64 -D` or `base64 --decode`.