### PR TITLE
kubectl run verb requires generator for pods

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -18,7 +18,7 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use 
 
 ```bash
 kubectl create namespace mynamespace
-kubectl run nginx --image=nginx --restart=Never -n mynamespace
+kubectl run nginx --generator=run-pod/v1 --image=nginx --restart=Never -n mynamespace
 ```
 
 </p>


### PR DESCRIPTION
It seems that the kubectl api has changed over time and the run verb creates a deployment as default unless a generator is supplied.
```
$ kubectl run --image=nginx -o yaml nginx  -n mynamespace
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
apiVersion: apps/v1
kind: Deployment
[...]
```

Achieved in kubectl version 1.16.2.

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T23:41:55Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```