### PR TITLE
Correcting revision number

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -346,13 +346,13 @@ kubectl rollout status deploy nginx # Everything should be OK
 </p>
 </details>
 
-### Check the details of the third revision (number 3)
+### Check the details of the fourth revision (number 4)
 
 <details><summary>show</summary>
 <p>
 
 ```bash
-kubectl rollout history deploy nginx --revision=3 # You'll also see the wrong image displayed here
+kubectl rollout history deploy nginx --revision=4 # You'll also see the wrong image displayed here
 ```
 
 </p>


### PR DESCRIPTION
As the first revision is for a new deployment.
The second revision is for version nginx:1.7.9
The third revision is for the rollout undo.
The fourth revision is for the wrong version: nginx:1.91