### PR TITLE
Cleanup deprecated --export flag

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -219,13 +219,19 @@ kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it --restar
 </p>
 </details>
 
-### Get this pod's YAML without cluster specific information
+### Get pod's YAML
 
 <details><summary>show</summary>
 <p>
 
 ```bash
-kubectl get po nginx -o yaml --export
+kubectl get po nginx -o yaml
+# or
+kubectl get po nginx -oyaml
+# or
+kubectl get po nginx --output yaml
+# or
+kubectl get po nginx --output=yaml
 ```
 
 </p>

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -23,7 +23,7 @@ kubectl create configmap config --from-literal=foo=lala --from-literal=foo2=lolo
 <p>
 
 ```bash
-kubectl get cm config -o yaml --export
+kubectl get cm config -o yaml
 # or
 kubectl describe cm config
 ```
@@ -63,7 +63,7 @@ echo -e "var1=val1\n# this is a comment\n\nvar2=val2\n#anothercomment" > config.
 
 ```bash
 kubectl create cm configmap3 --from-env-file=config.env
-kubectl get cm configmap3 -o yaml --export
+kubectl get cm configmap3 -o yaml
 ```
 
 </p>
@@ -83,7 +83,7 @@ echo -e "var3=val3\nvar4=val4" > config4.txt
 ```bash
 kubectl create cm configmap4 --from-file=special=config4.txt
 kubectl describe cm configmap4
-kubectl get cm configmap4 -o yaml --export
+kubectl get cm configmap4 -o yaml
 ```
 
 </p>
@@ -353,7 +353,7 @@ kubectl create secret generic mysecret2 --from-file=username
 <p>
 
 ```bash
-kubectl get secret mysecret2 -o yaml --export
+kubectl get secret mysecret2 -o yaml
 echo YWRtaW4K | base64 -d # on MAC it is -D, which decodes the value and shows 'admin'
 ```
 
@@ -485,7 +485,7 @@ Alternatively:
 
 ```bash
 # let's get a template easily
-kubectl get sa default -o yaml --export > sa.yaml
+kubectl get sa default -o yaml > sa.yaml
 vim sa.yaml
 ```
 

--- a/f.services.md
+++ b/f.services.md
@@ -219,7 +219,7 @@ kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Network
 kubectl run nginx --image=nginx --replicas=2 --port=80 --expose
 kubectl describe svc nginx # see the 'run=nginx' selector for the pods
 # or
-kubectl get svc nginx -o yaml --export
+kubectl get svc nginx -o yaml
 
 vi policy.yaml
 ```


### PR DESCRIPTION
This pull request intends to: 

- Cleanup `--export` repository references (issue #74)
- Add more syntax options to `output` objects to yaml.
---
> The flag --export is used to get a resource's YAML without cluster specific information.

As mentioned in the [Kubernetes Changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#deprecations), the `--export` flag for the kubectl get command is already deprecated and will be removed in v1.18. (#[73787](https://github.com/kubernetes/kubernetes/pull/73787))