### PR TITLE
Use label value without ambiguous meaning

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -208,7 +208,7 @@ kubectl delete deploy foo
 </p>
 </details>
 
-### Create an nginx deployment of 2 replicas, expose it via a ClusterIP service on port 80. Create a NetworkPolicy so that only pods with labels 'access: true' can access the deployment and apply it
+### Create an nginx deployment of 2 replicas, expose it via a ClusterIP service on port 80. Create a NetworkPolicy so that only pods with labels 'access: granted' can access the deployment and apply it
 
 kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Networking > [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 
@@ -237,7 +237,7 @@ spec:
   - from:
     - podSelector: # from pods
         matchLabels: # with this label
-          access: 'true' # 'true' *needs* quotes in YAML, apparently
+          access: granted
 ```
 
 ```bash
@@ -247,7 +247,7 @@ kubectl create -f policy.yaml
 # Check if the Network Policy has been created correctly
 # make sure that your cluster's network provider supports Network Policy (https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/#before-you-begin)
 kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- http://nginx:80                       # This should not work
-kubectl run busybox --image=busybox --rm -it --restart=Never --labels=access=true -- wget -O- http://nginx:80  # This should be fine
+kubectl run busybox --image=busybox --rm -it --restart=Never --labels=access=granted -- wget -O- http://nginx:80  # This should be fine
 ```
 
 </p>


### PR DESCRIPTION
YAML 1.1 parsers interpret strings that match the following regular expressions as Booleans. ie: using true (or variations thereof)

https://yaml.org/type/bool.html:
```
 y|Y|yes|Yes|YES|n|N|no|No|NO
|true|True|TRUE|false|False|FALSE
|on|On|ON|off|Off|OFF
```

The result is that trying to create a network policy using the suggested label will return:

```
Error from server (BadRequest): error when creating "network.yaml": NetworkPolicy in version "v1" cannot be handled as a NetworkPolicy: v1.NetworkPolicy.Spec: v1.NetworkPolicySpec.Ingress: []v1.NetworkPolicyIngressRule: v1.NetworkPolicyIngressRule.From: []v1.NetworkPolicyPeer: v1.NetworkPolicyPeer.PodSelector: v1.LabelSelector.MatchLabels: ReadString: expects " or n, but found t, error found in #10 byte of ...|"access":true}}}]}],|..., bigger context ...|{"from":[{"podSelector":{"matchLabels":{"access":true}}}]}],"podSelector":{"matchLabels":{"run":"ngi|...
```

I think there is some merit to teaching subtleties of YAML, and if you are keen on keeping on doing that, I'd suggest instead adding a follow up question, suggesting to change the label from "access: granted" to "access: yes" or "access: no" so that folks using it would be able to diagnose what is wrong faster.