### PR TITLE
Fix activeDeadlineSeconds value inconsistency

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -738,7 +738,7 @@ kubectl delete cj busybox
 kubectl create cronjob time-limited-job --image=busybox --restart=Never --dry-run --schedule="* * * * *" -o yaml -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster' > time-limited-job.yaml
 vi time-limited-job.yaml
 ```
-Add job.spec.activeDeadlineSeconds=30
+Add job.spec.activeDeadlineSeconds=17
 
 ```bash
 apiVersion: batch/v1beta1


### PR DESCRIPTION
In one place the instruction says that activeDeadlineSeconds has to be set to 17 seconds, but in another that value is 30.