### PR TITLE
Kubectl 1.18 updates

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -196,7 +196,13 @@ kubectl run nginx2 --image=nginx --expose --port 80
 ```bash
 # kubectl set image POD/POD_NAME CONTAINER_NAME=IMAGE_NAME:TAG
 kubectl set image pod/nginx nginx=nginx:1.7.1
-kubectl describe po nginx # you will see an event 'Container will be killed and recreated'
+# or save time by editing the file manually
+kubectl edit pod nginx
+#edit pod.spec.containers.image
+  - image: nginx:1.7.1
+
+# you will see an event 'Container will be killed and recreated'
+kubectl describe po nginx
 kubectl get po nginx -w # watch it
 ```
 *Note*: you can check pod's image by running
@@ -216,7 +222,7 @@ kubectl get po nginx -o jsonpath='{.spec.containers[].image}{"\n"}'
 ```bash
 kubectl get po -o wide # get the IP, will be something like '10.1.1.131'
 # create a temp busybox pod
-kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- 10.1.1.131:80
+kubectl run busybox --image=busybox --rm -it -- wget -O- 10.1.1.131:80
 ```
 
 Alternatively you can also try a more advanced option:
@@ -225,7 +231,7 @@ Alternatively you can also try a more advanced option:
 # Get IP of the nginx pod
 NGINX_IP=$(kubectl get pod nginx -o jsonpath='{.status.podIP}')
 # create a temp busybox pod
-kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it --restart=Never -- wget -O- $NGINX_IP:80
+kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it -- wget -O- $NGINX_IP:80
 ``` 
 
 </p>
@@ -241,9 +247,7 @@ kubectl get po nginx -o yaml
 # or
 kubectl get po nginx -oyaml
 # or
-kubectl get po nginx --output yaml
-# or
-kubectl get po nginx --output=yaml
+kubectl get po nginx -o yaml
 ```
 
 </p>
@@ -303,9 +307,9 @@ kubectl exec -it nginx -- /bin/sh
 <p>
 
 ```bash
-kubectl run busybox --image=busybox -it --restart=Never -- echo 'hello world'
+kubectl run busybox --image=busybox -it -- echo 'hello world'
 # or
-kubectl run busybox --image=busybox -it --restart=Never -- /bin/sh -c 'echo hello world'
+kubectl run busybox --image=busybox -it -- /bin/sh -c 'echo hello world'
 ```
 
 </p>
@@ -317,7 +321,7 @@ kubectl run busybox --image=busybox -it --restart=Never -- /bin/sh -c 'echo hell
 <p>
 
 ```bash
-kubectl run busybox --image=busybox -it --rm --restart=Never -- /bin/sh -c 'echo hello world'
+kubectl run busybox --image=busybox -it --rm -- /bin/sh -c 'echo hello world'
 kubectl get po # nowhere to be found :)
 ```
 
@@ -330,13 +334,13 @@ kubectl get po # nowhere to be found :)
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --env=var1=val1
+kubectl run nginx --image=nginx --env=var1=val1
 # then
 kubectl exec -it nginx -- env
 # or
 kubectl describe po nginx | grep val1
 # or
-kubectl run nginx --restart=Never --image=nginx --env=var1=val1 -it --rm -- env
+kubectl run nginx --image=nginx --env=var1=val1 -it --rm -- env
 ```
 
 </p>

--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -18,7 +18,10 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use 
 
 ```bash
 kubectl create namespace mynamespace
-kubectl run nginx --image=nginx --restart=Never -n mynamespace
+kubectl config set-context --current --namespace mynamespace
+kubectl run nginx --image=nginx 
+# Verify pods
+kubectl get pods
 ```
 
 </p>

--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -11,6 +11,26 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Acce
 
 kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use Port Forwarding to Access Applications in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 
+kubernetes.io > Reference > kubectl CLI > kubectl Cheat Sheet > Kubectl Autocomplete > [Kubectl Autocomplete](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-autocomplete)
+
+### Setup your test environment with your custom variables and autocompletion
+
+<details><summary>show</summary>
+<p>
+
+```bash
+# Consider setting an shell variable string to store this flag for speed. Speed is very important on the exam
+export do='--dry-run -o yaml'
+```
+```bash
+# Use autocompletion if you feel comfortable. Some people don't like this and others swear by it. Try both. Check the Autocomplete documentation above.
+
+source <(kubectl completion bash) # setup autocomplete in bash into the current shell, bash-completion package should be installed first.
+echo "source <(kubectl completion bash)" >> ~/.bashrc # add autocomplete permanently to your bash shell.
+```
+</p>
+</details>
+
 ### Create a namespace called 'mynamespace' and a pod with image nginx called nginx on this namespace
 
 <details><summary>show</summary>
@@ -36,10 +56,10 @@ Easily generate YAML with:
 
 ```bash
 kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
+# Isn't it a pain to type the dry run flag?
 ```
 ```bash
-# Consider setting an bash variable string to store this flag for speed. Speed is very important on the exam
-export do='--dry-run -o yaml'
+# Lets use the shell variable of the string
 kubectl run nginx --image=nginx $do > pod.yaml
 # You will use the dry run flag multiple times on the test.
 

--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -35,8 +35,16 @@ kubectl get pods
 Easily generate YAML with:
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
 ```
+```bash
+# Consider setting an bash variable string to store this flag for speed. Speed is very important on the exam
+export do='--dry-run -o yaml'
+kubectl run nginx --image=nginx $do > pod.yaml
+# You will use the dry run flag multiple times on the test.
+
+```
+
 
 ```bash
 cat pod.yaml
@@ -53,11 +61,10 @@ metadata:
 spec:
   containers:
   - image: nginx
-    imagePullPolicy: IfNotPresent
     name: nginx
     resources: {}
   dnsPolicy: ClusterFirst
-  restartPolicy: Never
+  restartPolicy: Always
 status: {}
 ```
 
@@ -68,7 +75,7 @@ kubectl create -f pod.yaml -n mynamespace
 Alternatively, you can run in one line
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml | kubectl create -n mynamespace -f -
+kubectl run nginx --image=nginx $do | kubectl create -n mynamespace -f -
 ```
 
 </p>
@@ -80,9 +87,9 @@ kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml | kubectl crea
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --command --restart=Never -it -- env # -it will help in seeing the output
+kubectl run busybox --image=busybox $do -it -- env # -it will help in seeing the output
 # or, just run it without -it
-kubectl run busybox --image=busybox --command --restart=Never -- env
+kubectl run busybox --image=busybox $do -- env
 # and then, check its logs
 kubectl logs busybox
 ```
@@ -97,7 +104,7 @@ kubectl logs busybox
 
 ```bash
 # create a  YAML template with this command
-kubectl run busybox --image=busybox --restart=Never --dry-run -o yaml --command -- env > envpod.yaml
+kubectl run busybox --image=busybox $do --command -- env > envpod.yaml
 # see it
 cat envpod.yaml
 ```
@@ -118,7 +125,7 @@ spec:
     name: busybox
     resources: {}
   dnsPolicy: ClusterFirst
-  restartPolicy: Never
+  restartPolicy: Always
 status: {}
 ```
 
@@ -137,7 +144,7 @@ kubectl logs busybox
 <p>
 
 ```bash
-kubectl create namespace myns -o yaml --dry-run
+kubectl create namespace myns $do
 ```
 
 </p>
@@ -149,7 +156,7 @@ kubectl create namespace myns -o yaml --dry-run
 <p>
 
 ```bash
-kubectl create quota myrq --hard=cpu=1,memory=1G,pods=2 --dry-run -o yaml
+kubectl create quota myrq --hard=cpu=1,memory=1G,pods=2 $do
 ```
 
 </p>
@@ -173,7 +180,9 @@ kubectl get po --all-namespaces
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --port=80
+kubectl run nginx2 --image=nginx $do --expose --port 80 
+# Verify what you have created. If it looks good go ahead and create it. 
+kubectl run nginx2 --image=nginx --expose --port 80
 ```
 
 </p>

--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -18,7 +18,7 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use 
 
 ```bash
 kubectl create namespace mynamespace
-kubectl config set-context --current --namespace mynamespace
+kubectl config set-context --current --namespace mynamespace      # The exam requires you to switch into your namespace and context every question.
 kubectl run nginx --image=nginx 
 # Verify pods
 kubectl get pods

--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -9,7 +9,7 @@
 Easiest way to do it is create a pod with a single container and save its definition in a YAML file:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run -- /bin/sh -c 'echo hello;sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox $do -- /bin/sh -c 'echo hello;sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -10,9 +10,9 @@ kubernetes.io > Documentation > Concepts > Overview > [Labels and Selectors](htt
 <p>
 
 ```bash
-kubectl run nginx1 --image=nginx --restart=Never --labels=app=v1
-kubectl run nginx2 --image=nginx --restart=Never --labels=app=v1
-kubectl run nginx3 --image=nginx --restart=Never --labels=app=v1
+kubectl run nginx1 --image=nginx --labels=app=v1
+kubectl run nginx2 --image=nginx --labels=app=v1
+kubectl run nginx3 --image=nginx --labels=app=v1
 ```
 
 </p>
@@ -188,7 +188,7 @@ kubectl run nginx --image=nginx:1.7.8 --replicas=2 --port=80
 **However**, `kubectl run` for Deployments is Deprecated and will be removed in a future version. What you can do is:
 
 ```bash
-kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run -o yaml > deploy.yaml
+kubectl create deployment nginx  --image=nginx:1.7.8  $do > deploy.yaml
 vi deploy.yaml
 # change the replicas field from 1 to 2
 # add this section to the container spec and save the deploy.yaml file
@@ -200,7 +200,7 @@ kubectl apply -f deploy.yaml
 or, do something like:
 
 ```bash
-kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run -o yaml | sed 's/replicas: 1/replicas: 2/g'  | sed 's/image: nginx:1.7.8/image: nginx:1.7.8\n        ports:\n        - containerPort: 80/g' | kubectl apply -f -
+kubectl create deployment nginx  --image=nginx:1.7.8  $do | sed 's/replicas: 1/replicas: 2/g'  | sed 's/image: nginx:1.7.8/image: nginx:1.7.8\n        ports:\n        - containerPort: 80/g' | kubectl apply -f -
 ```
 
 </p>
@@ -457,13 +457,35 @@ kubectl delete deploy/nginx hpa/nginx
 <p>
 
 ```bash
-kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+kubectl create job pi --image=perl $do -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+# Validate the yaml
 ```
-
-**However**, `kubectl run` for Job is Deprecated and will be removed in a future version. What you can do is:
-
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: pi
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - command:
+        - perl
+        - -Mbignum=bpi
+        - -wle
+        - print bpi(2000)
+        image: perl
+        name: pi
+        resources: {}
+      restartPolicy: Never
+status: {}
+```
 ```bash
-kubectl create job pi  --image=perl -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+# Create it
+kubectl create job pi --image=perl -- perl -Mbignum=bpi -wle 'print bpi(2000)'
 ```
 
 </p>
@@ -488,12 +510,6 @@ kubectl delete job pi
 
 <details><summary>show</summary>
 <p>
-
-```bash
-kubectl run busybox --image=busybox --restart=OnFailure -- /bin/sh -c 'echo hello;sleep 30;echo world'
-```
-
-**However**, `kubectl run` for Job is Deprecated and will be removed in a future version. What you can do is:
 
 ```bash
 kubectl create job busybox --image=busybox -- /bin/sh -c 'echo hello;sleep 30;echo world'
@@ -547,7 +563,7 @@ kubectl delete job busybox
 <p>
   
 ```bash
-kubectl create job busybox --image=busybox --dry-run -o yaml -- /bin/sh -c 'while true; do echo hello; sleep 10;done' > job.yaml
+kubectl create job busybox --image=busybox $do -- /bin/sh -c 'while true; do echo hello; sleep 10;done' > job.yaml
 vi job.yaml
 ```
   
@@ -589,7 +605,7 @@ status: {}
 <p>
 
 ```bash
-kubectl create job busybox --image=busybox --dry-run -o yaml -- /bin/sh -c 'echo hello;sleep 30;echo world' > job.yaml
+kubectl create job busybox --image=busybox $do -- /bin/sh -c 'echo hello;sleep 30;echo world' > job.yaml
 vi job.yaml
 ```
 
@@ -700,12 +716,6 @@ kubernetes.io > Documentation > Tasks > Run Jobs > [Running Automated Tasks with
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=OnFailure --schedule="*/1 * * * *" -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster'
-```
-
-**However**, `kubectl run` for CronJob is Deprecated and will be removed in a future version. What you can do is:
-
-```bash
 kubectl create cronjob busybox --image=busybox --schedule="*/1 * * * *" -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster'
 ```
 
@@ -735,7 +745,7 @@ kubectl delete cj busybox
 <p>
 
 ```bash
-kubectl create cronjob time-limited-job --image=busybox --restart=Never --dry-run --schedule="* * * * *" -o yaml -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster' > time-limited-job.yaml
+kubectl create cronjob time-limited-job --image=busybox $do --schedule="* * * * *" -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster' > time-limited-job.yaml
 vi time-limited-job.yaml
 ```
 Add job.spec.activeDeadlineSeconds=17

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -96,7 +96,7 @@ kubectl get cm configmap4 -o yaml
 
 ```bash
 kubectl create cm options --from-literal=var5=val5
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -140,7 +140,7 @@ kubectl exec -it nginx -- env | grep option # will show 'option=val5'
 
 ```bash
 kubectl create configmap anotherone --from-literal=var6=val6 --from-literal=var7=val7
-kubectl run --restart=Never nginx --image=nginx -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -181,7 +181,7 @@ kubectl exec -it nginx -- env
 
 ```bash
 kubectl create configmap cmvolume --from-literal=var8=val8 --from-literal=var9=val9
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -231,7 +231,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -266,7 +266,7 @@ status: {}
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -305,7 +305,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Assign 
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
+kubectl run nginx --image=nginx --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
 ```
 
 </p>
@@ -372,7 +372,7 @@ kubectl get secret mysecret2 -o jsonpath='{.data.username}{"\n"}' | base64 -d  #
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -419,7 +419,7 @@ cat /etc/foo/username # shows admin
 
 ```bash
 kubectl delete po nginx
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -514,14 +514,14 @@ kubectl create -f sa.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --serviceaccount=myuser -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx --serviceaccount=myuser $do > pod.yaml
 kubectl apply -f pod.yaml
 ```
 
 or you can add manually:
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 

--- a/e.observability.md
+++ b/e.observability.md
@@ -11,7 +11,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run -o yaml > pod.yaml
+kubectl run nginx --image=nginx $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -96,7 +96,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --dry-run -o yaml --restart=Never --port=80 > pod.yaml
+kubectl run nginx --image=nginx --port=80 $do > pod.yaml
 vi pod.yaml
 ```
 
@@ -142,7 +142,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
+kubectl run busybox --image=busybox -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
 kubectl logs busybox -f # follow the logs
 ```
 
@@ -157,7 +157,7 @@ kubectl logs busybox -f # follow the logs
 <p>
 
 ```bash
-kubectl run busybox --restart=Never --image=busybox -- /bin/sh -c 'ls /notexist'
+kubectl run busybox --image=busybox -- /bin/sh -c 'ls /notexist'
 # show that there's an error
 kubectl logs busybox
 kubectl describe po busybox
@@ -173,7 +173,7 @@ kubectl delete po busybox
 <p>
 
 ```bash
-kubectl run busybox --restart=Never --image=busybox -- notexist
+kubectl run busybox --image=busybox -- notexist
 kubectl logs busybox # will bring nothing! container never started
 kubectl describe po busybox # in the events section, you'll see the error
 # also...

--- a/f.services.md
+++ b/f.services.md
@@ -121,7 +121,7 @@ kubectl run foo --image=dgkanatsios/simpleapp --labels=app=foo --port=8080 --rep
 Or, you can use the more recent approach of creating the requested deployment as kubectl run has been deprecated.
 
 ```bash
-kubectl create deploy foo --image=dgkanatsios/simpleapp -$do > foo.yml
+kubectl create deploy foo --image=dgkanatsios/simpleapp $do > foo.yml
 
 vi foo.yml
 ```

--- a/f.services.md
+++ b/f.services.md
@@ -7,7 +7,7 @@
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --port=80 --expose
+kubectl run nginx --image=nginx --port=80 --expose
 # observe that a pod as well as a service are created
 ```
 
@@ -35,7 +35,7 @@ kubectl get ep # endpoints
 
 ```bash
 kubectl get svc nginx # get the IP (something like 10.108.93.130)
-kubectl run busybox --rm --image=busybox -it --restart=Never -- sh
+kubectl run busybox --rm --image=busybox -it -- sh
 wget -O- IP:80
 exit
 ```
@@ -46,7 +46,7 @@ or
 
 ```bash
 IP=$(kubectl get svc nginx --template={{.spec.clusterIP}}) # get the IP (something like 10.108.93.130)
-kubectl run busybox --rm --image=busybox -it --restart=Never --env="IP=$IP" -- wget -O- $IP:80 --timeout 2
+kubectl run busybox --rm --image=busybox -it --env="IP=$IP" -- wget -O- $IP:80 --timeout 2
 # Tip: --timeout is optional, but it helps to get answer more quickly when connection fails (in seconds vs minutes)
 ```
 
@@ -121,7 +121,7 @@ kubectl run foo --image=dgkanatsios/simpleapp --labels=app=foo --port=8080 --rep
 Or, you can use the more recent approach of creating the requested deployment as kubectl run has been deprecated.
 
 ```bash
-kubectl create deploy foo --image=dgkanatsios/simpleapp --dry-run -o yaml > foo.yml
+kubectl create deploy foo --image=dgkanatsios/simpleapp -$do > foo.yml
 
 vi foo.yml
 ```
@@ -167,7 +167,7 @@ status: {}
 
 ```bash
 kubectl get pods -l app=foo -o wide # 'wide' will show pod IPs
-kubectl run busybox --image=busybox --restart=Never -it --rm -- sh
+kubectl run busybox --image=busybox -it --rm -- sh
 wget -O- POD_IP:8080 # do not try with pod name, will not work
 # try hitting all IPs to confirm that hostname is different
 exit
@@ -198,7 +198,7 @@ kubectl get endpoints foo # you will see the IPs of the three replica nodes, lis
 
 ```bash
 kubectl get svc # get the foo service ClusterIP
-kubectl run busybox --image=busybox -it --rm --restart=Never -- sh
+kubectl run busybox --image=busybox -it --rm -- sh
 wget -O- foo:6262 # DNS works! run it many times, you'll see different pods responding
 wget -O- SERVICE_CLUSTER_IP:6262 # ClusterIP works as well
 # you can also kubectl logs on deployment pods to see the container logs
@@ -247,8 +247,8 @@ kubectl create -f policy.yaml
 
 # Check if the Network Policy has been created correctly
 # make sure that your cluster's network provider supports Network Policy (https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/#before-you-begin)
-kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- http://nginx:80 --timeout 2                          # This should not work. --timeout is optional here. But it helps to get answer more quickly (in seconds vs minutes)
-kubectl run busybox --image=busybox --rm -it --restart=Never --labels=access=granted -- wget -O- http://nginx:80 --timeout 2  # This should be fine
+kubectl run busybox --image=busybox --rm -it -- wget -O- http://nginx:80 --timeout 2                          # This should not work. --timeout is optional here. But it helps to get answer more quickly (in seconds vs minutes)
+kubectl run busybox --image=busybox --rm -it --labels=access=granted -- wget -O- http://nginx:80 --timeout 2  # This should be fine
 ```
 
 </p>

--- a/g.state.md
+++ b/g.state.md
@@ -17,7 +17,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 Easiest way to do this is to create a template pod with:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run -- /bin/sh -c 'sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox $do -- /bin/sh -c 'sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 Copy paste the container definition and type the lines that have a comment in the end:
@@ -165,7 +165,7 @@ kubectl get pv # will show as 'Bound' as well
 Create a skeleton pod:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run -- /bin/sh -c 'sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox $do -- /bin/sh -c 'sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 
@@ -241,7 +241,7 @@ kubectl delete po busybox busybox2
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -- sleep 3600
+kubectl run busybox --image=busybox -- sleep 3600
 kubectl cp busybox:/etc/passwd ./passwd # kubectl cp command
 # previous command might report an error, feel free to ignore it since copy command works
 cat passwd


### PR DESCRIPTION
I added a setup section that includes a shell variable for --dry-run=client and update the questions to reflect that. 

I also updated the commands that use --restart=onFailure and --restart=Never

I also deleted the deprecation warnings. It has already been removed from the exam so there is not need to mention anything < 1.18.