### PR TITLE
Update a.core_concepts.md

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -176,7 +176,7 @@ kubectl run nginx --image=nginx --restart=Never --port=80
 </p>
 </details>
 
-### Change pod's image to nginx:1.7.1. Observe that the pod will be killed and recreated as soon as the image gets pulled
+### Change pod's image to nginx:1.7.1. Observe that the container will be restarted as soon as the image gets pulled
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
I think Pod is not destroyed and created, but container is restarted.

Proof:

````
➤ k delete po --all --force --grace-period=0                                  vagrant@archlinux
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "nginx" force deleted
[15:52] ~
➤ k run nginx --image=nginx:1.16-alpine --restart=Never --port=80             vagrant@archlinux
pod/nginx created
[15:52] ~
➤ k get po nginx -o jsonpath='{.spec.containers[].image}{"\n"}'               vagrant@archlinux
nginx:1.16-alpine
[15:52] ~
➤ k get po                                                                    vagrant@archlinux
NAME    READY   STATUS    RESTARTS   AGE
nginx   1/1     Running   0          34s
[15:52] ~
➤ k set image pod nginx nginx=nginx:1.7.1                                     vagrant@archlinux
pod/nginx image updated
[15:52] ~
➤ k get po                                                                    vagrant@archlinux
NAME    READY   STATUS    RESTARTS   AGE
nginx   1/1     Running   1          46s
[15:53] ~
➤ k get po nginx -o jsonpath='{.spec.containers[].image}{"\n"}'               vagrant@archlinux
nginx:1.7.1
[15:53] ~
➤ k describe po nginx                                                         vagrant@archlinuxName:         nginx
Namespace:    default
Priority:     0
Node:         archlinux/10.0.2.15
Start Time:   Sat, 30 May 2020 15:52:17 +0000
Labels:       run=nginx
Annotations:  <none>
Status:       Running
IP:           172.17.0.7
IPs:
  IP:  172.17.0.7
Containers:
  nginx:
    Container ID:   docker://49fd0ba386ace604b7096b07cb649a015f1ce030e07a104018361823e9b5d60c
    Image:          nginx:1.7.1
    Image ID:       docker-pullable://nginx@sha256:7fbe0579e123f3d2b29c9159e9a80547fb72621bb419e52d98c679ddbf1055a1
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Sat, 30 May 2020 15:53:00 +0000
    Last State:     Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Sat, 30 May 2020 15:52:40 +0000
      Finished:     Sat, 30 May 2020 15:52:59 +0000
    Ready:          True
    Restart Count:  1
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-l5d2z (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  default-token-l5d2z:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-l5d2z
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type    Reason     Age                From                Message
  ----    ------     ----               ----                -------
  Normal  Scheduled  <unknown>          default-scheduler   Successfully assigned default/nginx to archlinux
  Normal  Pulling    75s                kubelet, archlinux  Pulling image "nginx:1.16-alpine"
  Normal  Pulled     52s                kubelet, archlinux  Successfully pulled image "nginx:1.16-alpine"
  Normal  Killing    33s                kubelet, archlinux  Container nginx definition changed, will be restarted
  Normal  Created    32s (x2 over 52s)  kubelet, archlinux  Created container nginx
  Normal  Started    32s (x2 over 52s)  kubelet, archlinux  Started container nginx
  Normal  Pulled     32s                kubelet, archlinux  Container image "nginx:1.7.1" already present on machine
````
Conclusion:
The container is not restarted but same pod is kept unlike what would do a deployment and replica set