### PR TITLE
Add volumeName in the PersistentVolumeClaim yaml

### DIFF
--- a/g.state.md
+++ b/g.state.md
@@ -139,6 +139,7 @@ spec:
   resources:
     requests:
       storage: 4Gi
+  volumeName: myvolume
 ```
 
 Create it on the cluster:

--- a/g.state.md
+++ b/g.state.md
@@ -118,7 +118,7 @@ kubectl get pv
 </p>
 </details>
 
-### Create a PersistentVolumeClaim for this storage class, called mypvc, a request of 4Gi and an accessMode of ReadWriteOnce, with the storageClassName of normal, and save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
+### Create a PersistentVolumeClaim for this storage class, called mypvc, claim from myvolume, with a request of 4Gi, an accessMode of ReadWriteOnce and the storageClassName of normal, save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
The `PersistentVolumeClaim` is missing `volumeName` in it's spec.
Which will create a pvc that's always in pending status.