### PR TITLE
add additional way for checking "annotations"

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -141,6 +141,10 @@ kubectl annotate po nginx{1..3} description='my description'
 
 ```bash
 kubectl describe po nginx1 | grep -i 'annotations'
+
+# or
+
+kubectl get pods -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
 ```
 
 As an alternative to using `| grep` you can use jsonPath like `kubectl get po nginx -o jsonpath='{.metadata.annotations}{"\n"}'`


### PR DESCRIPTION
kubectl get pods  -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
is a more distinctive way of checking the annotations - probably better than to grep the result of kubectl describe - and certainly more straight forward as jsonpath :-)