### PR TITLE
corrected command

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -306,7 +306,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Assign 
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
+kubectl run nginx --image=nginx --restart=Never --requests=cpu=100m,memory=256Mi --limits=cpu=200m,memory=512Mi
 ```
 
 </p>


### PR DESCRIPTION
The current command is giving error:
kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
**error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'**

I have corrected it. 

kubectl run nginx --image=nginx --restart=Never --requests=cpu=1 --limits=cpu=2
pod/nginx created