### PR TITLE
Fixes description of added line about cronjob terminating condition in c.pod_design.md

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -747,7 +747,7 @@ kubectl delete cj busybox
 kubectl create cronjob time-limited-job --image=busybox --restart=Never --dry-run=client --schedule="* * * * *" -o yaml -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster' > time-limited-job.yaml
 vi time-limited-job.yaml
 ```
-Add job.spec.activeDeadlineSeconds=17
+Add job.spec.startingDeadlineSeconds=17
 
 ```bash
 apiVersion: batch/v1beta1


### PR DESCRIPTION
In the yaml, added line is written as below:
```
  startingDeadlineSeconds: 17 # add this line
```

But description of that written above is `Add job.spec.activeDeadlineSeconds=17`

Actually I don't understand properly which statement is correct, so I hope someone will fix it if my PR is not right.