### PR TITLE
Using run with --replicas=3

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -114,11 +114,7 @@ kubectl delete pod nginx # Deletes the pod
 <details><summary>show</summary>
 <p>
 
-
-```bash
-kubectl run foo --image=dgkanatsios/simpleapp --labels=app=foo --port=8080 --replicas=3
-```
-Or, you can use the more recent approach of creating the requested deployment as kubectl run has been deprecated.
+Use the more recent approach of creating the requested deployment as kubectl run has been deprecated.
 
 ```bash
 kubectl create deploy foo --image=dgkanatsios/simpleapp --dry-run=client -o yaml > foo.yml


### PR DESCRIPTION
Using `kubectl run` with `--replicas=3` does not create a deployment anymore, but a pod with `--replicas` flag ignored. So this solution is not valid anymore.