### PR TITLE
Update f.services.md

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -114,12 +114,6 @@ kubectl delete pod nginx # Deletes the pod
 <details><summary>show</summary>
 <p>
 
-
-```bash
-kubectl run foo --image=dgkanatsios/simpleapp --labels=app=foo --port=8080 --replicas=3
-```
-Or, you can use the more recent approach of creating the requested deployment as kubectl run has been deprecated.
-
 ```bash
 kubectl create deploy foo --image=dgkanatsios/simpleapp --dry-run=client -o yaml > foo.yml
 


### PR DESCRIPTION
Removing the run command for the creation of the deployment as this will create only confusion although the explanation is mentioned below that. It seems unnecessary to have a command which is deprecated.