### PR TITLE
Update e.observability.md

### DIFF
--- a/e.observability.md
+++ b/e.observability.md
@@ -142,7 +142,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
+kubectl run busybox --image=busybox --restart=Never -- /bin/sh -c 'i=0; while true; do echo $i: $(date); i=$((i+1)); sleep 1; done'
 kubectl logs busybox -f # follow the logs
 ```
 


### PR DESCRIPTION
With the double-quotes enclosing :  $i: $(date) , it not yielding the logs. Therefore by removing the double quotes it works just fine.