### PR TITLE
Fixed TLS certificate validation not implemented

### DIFF
--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -51,7 +51,7 @@ kubectl delete po busybox
 </details>
 
 
-### Create nginx pod exposed at port 80. Add an busybox init container which downloads the k8s page by "wget -O /work-dir/index.html http://kubernetes.io". Make a volume of type emptyDir and mount it in both pods. For nginx mount it on "/usr/share/nginx/html" and for the initcontainer use mount it on "/work-dir". When done, get the IP of the nginx pod and create a busybox pod and run wget -O- IP
+### Create nginx pod exposed at port 80. Add an busybox init container which downloads the k8s page by "wget -O /work-dir/index.html http://neverssl.com/online". Make a volume of type emptyDir and mount it in both pods. For nginx mount it on "/usr/share/nginx/html" and for the initcontainer use mount it on "/work-dir". When done, get the IP of the nginx pod and create a busybox pod and run wget -O- IP
 
 <details><summary>show</summary>
 <p>
@@ -86,7 +86,7 @@ initContainers:
 - args:
   - /bin/sh
   - -c
-  - wget -O /work-dir/index.html http://kubernetes.io
+  - wget -O /work-dir/index.html http://neverssl.com/online
   image: busybox
   name: box
   volumeMounts:
@@ -109,7 +109,7 @@ spec:
   - args: #
     - /bin/sh #
     - -c #
-    - wget -O /work-dir/index.html http://kubernetes.io #
+    - wget -O /work-dir/index.html http://neverssl.com/online #
     image: busybox #
     name: box #
     volumeMounts: #


### PR DESCRIPTION
Issue is caused by busybox's wget, which cannot validate SSL connections. The easy solution is to use a http page that doesn't redirect to https, which kubernetes.io does, but http://neverssl.com/online does not.  To replicate the problem create the box pod with the initContainer and the regular Container as per answer example and then run "kubectl logs box -c box" to see the error messages. The status of the pod will also be "Init:CrashLoopBackOff" with constant restarts because it fails at the init stage.

Reference: https://github.com/moby/moby/issues/41348