### PR TITLE
Fix a typo when exposing a deployment in Services & Deployment section

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -179,7 +179,7 @@ kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Network
 
 ```bash
 kubectl create deployment nginx --image=nginx --replicas=2
-kubectl expose ndeployment nginx --port=80
+kubectl expose deployment nginx --port=80
 
 kubectl describe svc nginx # see the 'run=nginx' selector for the pods
 # or


### PR DESCRIPTION
The goal of this PR is to fix a small typo in `Services & Deployment` section