### PR TITLE
Remove outdated syntax

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -230,11 +230,6 @@ or, do something like:
 kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run=client -o yaml | sed 's/replicas: 1/replicas: 2/g'  | sed 's/image: nginx:1.7.8/image: nginx:1.7.8\n        ports:\n        - containerPort: 80/g' | kubectl apply -f -
 ```
 
-or, 
-```bash
-kubectl create deploy nginx --image=nginx:1.7.8 --replicas=2 --port=80
-```
-
 </p>
 </details>
 


### PR DESCRIPTION
Deployment can not be created directly with port and replicas in the newer versions of kubectl.

See  https://github.com/dgkanatsios/CKAD-exercises/issues/143