### PR TITLE
Added missing namespace in posted YAML

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -47,6 +47,7 @@ metadata:
   labels:
     run: nginx
   name: nginx
+  namespace: mynamespace
 spec:
   containers:
   - image: nginx

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -506,6 +506,12 @@ kubectl get po # get the pod name
 kubectl logs pi-**** # get the pi numbers
 kubectl delete job pi
 ```
+OR 
+
+```bash
+kubectl get jobs -w # wait till 'SUCCESSFUL' is 1 (will take some time, perl image might be big)
+kubectl logs job/pi
+```
 
 </p>
 </details>

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -511,6 +511,7 @@ OR
 ```bash
 kubectl get jobs -w # wait till 'SUCCESSFUL' is 1 (will take some time, perl image might be big)
 kubectl logs job/pi
+kubectl delete job pi
 ```
 
 </p>

--- a/f.services.md
+++ b/f.services.md
@@ -181,7 +181,7 @@ kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Network
 kubectl create deployment nginx --image=nginx --replicas=2
 kubectl expose deployment nginx --port=80
 
-kubectl describe svc nginx # see the 'run=nginx' selector for the pods
+kubectl describe svc nginx # see the 'app=nginx' selector for the pods
 # or
 kubectl get svc nginx -o yaml
 
@@ -196,7 +196,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      run: nginx # selector for the pods
+      app: nginx # selector for the pods
   ingress: # allow ingress traffic
   - from:
     - podSelector: # from pods


### PR DESCRIPTION
In the second exercise of core concepts, the solution  asks to run the command:

`kubectl run nginx --image=nginx --restart=Never --dry-run=client -n mynamespace -o yaml > pod.yaml`

However the posted resulting YAML is currently missing the namespace, which does not match the result of running the command above. Fixed by adding the namespace to the yaml