### PR TITLE
Update deployment creation

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -215,13 +215,7 @@ kubernetes.io > Documentation > Concepts > Workloads > Controllers > [Deployment
 <p>
 
 ```bash
-kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run=client -o yaml > deploy.yaml
-vi deploy.yaml
-# change the replicas field from 1 to 2
-# add this section to the container spec and save the deploy.yaml file
-# ports:
-#   - containerPort: 80
-kubectl apply -f deploy.yaml
+kubectl create deployment nginx  --image=nginx:1.7.8 --replicas=2 --port=80
 ```
 
 or, do something like:


### PR DESCRIPTION
The CKAD exam environment is currently running Kubernetes v1.19, which supports deployment creation with --replicas and --port flags

#[91562](https://github.com/kubernetes/kubernetes/pull/91562)
#[91113](https://github.com/kubernetes/kubernetes/pull/91113)