### PR TITLE
Remove "--replicas --port" on kubectl  create deployment

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -230,11 +230,6 @@ or, do something like:
 kubectl create deployment nginx  --image=nginx:1.7.8  --dry-run=client -o yaml | sed 's/replicas: 1/replicas: 2/g'  | sed 's/image: nginx:1.7.8/image: nginx:1.7.8\n        ports:\n        - containerPort: 80/g' | kubectl apply -f -
 ```
 
-or, 
-```bash
-kubectl create deploy nginx --image=nginx:1.7.8 --replicas=2 --port=80
-```
-
 </p>
 </details>
 

--- a/f.services.md
+++ b/f.services.md
@@ -185,7 +185,16 @@ kubernetes.io > Documentation > Concepts > Services, Load Balancing, and Network
 <p>
 
 ```bash
-kubectl create deployment nginx --image=nginx --replicas=2
+
+kubectl create deploy foo  --image=nginx  --dry-run=client -o yaml > deploy.yaml
+vi deploy.yaml
+# change the replicas field from 1 to 2
+# add this section to the container spec and save the deploy.yaml file
+# ports:
+#   - containerPort: 80
+kubectl apply -f deploy.yaml
+
+
 kubectl expose deployment nginx --port=80
 
 kubectl describe svc nginx # see the 'app=nginx' selector for the pods

--- a/f.services.md
+++ b/f.services.md
@@ -115,8 +115,15 @@ kubectl delete pod nginx # Deletes the pod
 <p>
 
 ```bash
-kubectl create deploy foo --image=dgkanatsios/simpleapp --port=8080 --replicas=3
+kubectl create deploy foo  --image=dgkanatsios/simpleapp  --dry-run=client -o yaml > deploy.yaml
+vi deploy.yaml
+# change the replicas field from 1 to 3
+# add this section to the container spec and save the deploy.yaml file
+# ports:
+#   - containerPort: 8080
+kubectl apply -f deploy.yaml
 ```
+
 </p>
 </details>
 


### PR DESCRIPTION
The command to create deployment changing replicas and adding port in a single line is no longer available at least on the current version of k8s 1.19. 

```
bash-3.2$ kubectl create deploy nginx --image=nginx:1.7.8 --replicas=2 --port=80
Error: unknown flag: --replicas
See 'kubectl create deployment --help' for usage.
bash-3.2$
```

The correct answer is already provided. 