### PR TITLE
Add missing ns

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -60,7 +60,7 @@ status: {}
 ```
 
 ```bash
-kubectl create -f pod.yaml -n mynamespace
+kubectl create -f pod.yaml
 ```
 
 Alternatively, you can run in one line

--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -47,6 +47,7 @@ metadata:
   labels:
     run: nginx
   name: nginx
+  namespace: mynamespace
 spec:
   containers:
   - image: nginx


### PR DESCRIPTION
Given the command `kubectl run nginx --image=nginx --restart=Never --dry-run=client -n mynamespace -o yaml` the resulting yaml is missing the `namespace` key. This change adds the missing namespace key. Also since the namespace key is now present in the yaml I've removed it from the apply since it's not needed there.