### PR TITLE
Update b.multi_container_pods.md to make the commands almost copy pastable.

### DIFF
--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -135,7 +135,7 @@ kubectl apply -f pod-init.yaml
 kubectl get po -o wide
 
 # Execute wget
-kubectl run box --image=busybox --restart=Never -it --rm -- /bin/sh -c "wget -O- IP"
+kubectl run box-test --image=busybox --restart=Never -it --rm -- /bin/sh -c "wget -O- IP"
 
 # you can do some cleanup
 kubectl delete po box


### PR DESCRIPTION
When following the answer, i ran into the issue that the "box" pods already exists. We created it with the yaml file, therefore i needed to change the name of the wget-executing container to make it work. Should'nt be a problem for most of the folks preparing for the exam, but to make it "copy-pastable" i changed the name from "box" to "box-test" as we are testing our "box" pod.