### PR TITLE
Removed old trick to create pods with kubectl run

### DIFF
--- a/a.core_concepts.md
+++ b/a.core_concepts.md
@@ -18,7 +18,7 @@ kubernetes.io > Documentation > Tasks > Access Applications in a Cluster > [Use 
 
 ```bash
 kubectl create namespace mynamespace
-kubectl run nginx --image=nginx --restart=Never -n mynamespace
+kubectl run nginx --image=nginx -n mynamespace
 ```
 
 </p>
@@ -32,7 +32,7 @@ kubectl run nginx --image=nginx --restart=Never -n mynamespace
 Easily generate YAML with:
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -n mynamespace -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -n mynamespace -o yaml > pod.yaml
 ```
 
 ```bash
@@ -65,7 +65,7 @@ kubectl create -f pod.yaml -n mynamespace
 Alternatively, you can run in one line
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml | kubectl create -n mynamespace -f -
+kubectl run nginx --image=nginx --dry-run=client -o yaml | kubectl create -n mynamespace -f -
 ```
 
 </p>
@@ -77,9 +77,9 @@ kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml | kubec
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --command --restart=Never -it -- env # -it will help in seeing the output
+kubectl run busybox --image=busybox --command -it -- env # -it will help in seeing the output
 # or, just run it without -it
-kubectl run busybox --image=busybox --command --restart=Never -- env
+kubectl run busybox --image=busybox --command -- env
 # and then, check its logs
 kubectl logs busybox
 ```
@@ -94,7 +94,7 @@ kubectl logs busybox
 
 ```bash
 # create a  YAML template with this command
-kubectl run busybox --image=busybox --restart=Never --dry-run=client -o yaml --command -- env > envpod.yaml
+kubectl run busybox --image=busybox --dry-run=client -o yaml --command -- env > envpod.yaml
 # see it
 cat envpod.yaml
 ```
@@ -174,7 +174,7 @@ kubectl get po -A
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --port=80
+kubectl run nginx --image=nginx --port=80
 ```
 
 </p>
@@ -225,7 +225,7 @@ kubectl get po nginx -o jsonpath='{.spec.containers[].image}{"\n"}'
 ```bash
 kubectl get po -o wide # get the IP, will be something like '10.1.1.131'
 # create a temp busybox pod
-kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- 10.1.1.131:80
+kubectl run busybox --image=busybox --rm -it -- wget -O- 10.1.1.131:80
 ```
 
 Alternatively you can also try a more advanced option:
@@ -234,13 +234,13 @@ Alternatively you can also try a more advanced option:
 # Get IP of the nginx pod
 NGINX_IP=$(kubectl get pod nginx -o jsonpath='{.status.podIP}')
 # create a temp busybox pod
-kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it --restart=Never -- sh -c 'wget -O- $NGINX_IP:80'
+kubectl run busybox --image=busybox --env="NGINX_IP=$NGINX_IP" --rm -it -- sh -c 'wget -O- $NGINX_IP:80'
 ``` 
 
 Or just in one line:
 
 ```bash
-kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- $(kubectl get pod nginx -o jsonpath='{.status.podIP}:{.spec.containers[0].ports[0].containerPort}')
+kubectl run busybox --image=busybox --rm -it -- wget -O- $(kubectl get pod nginx -o jsonpath='{.status.podIP}:{.spec.containers[0].ports[0].containerPort}')
 ```
 
 </p>
@@ -318,9 +318,9 @@ kubectl exec -it nginx -- /bin/sh
 <p>
 
 ```bash
-kubectl run busybox --image=busybox -it --restart=Never -- echo 'hello world'
+kubectl run busybox --image=busybox -it -- echo 'hello world'
 # or
-kubectl run busybox --image=busybox -it --restart=Never -- /bin/sh -c 'echo hello world'
+kubectl run busybox --image=busybox -it -- /bin/sh -c 'echo hello world'
 ```
 
 </p>
@@ -332,7 +332,7 @@ kubectl run busybox --image=busybox -it --restart=Never -- /bin/sh -c 'echo hell
 <p>
 
 ```bash
-kubectl run busybox --image=busybox -it --rm --restart=Never -- /bin/sh -c 'echo hello world'
+kubectl run busybox --image=busybox -it --rm -- /bin/sh -c 'echo hello world'
 kubectl get po # nowhere to be found :)
 ```
 
@@ -345,7 +345,7 @@ kubectl get po # nowhere to be found :)
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --env=var1=val1
+kubectl run nginx --image=nginx --env=var1=val1
 # then
 kubectl exec -it nginx -- env
 # or
@@ -353,7 +353,7 @@ kubectl exec -it nginx -- sh -c 'echo $var1'
 # or
 kubectl describe po nginx | grep val1
 # or
-kubectl run nginx --restart=Never --image=nginx --env=var1=val1 -it --rm -- env
+kubectl run nginx --image=nginx --env=var1=val1 -it --rm -- env
 ```
 
 </p>

--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -9,7 +9,7 @@
 Easiest way to do it is create a pod with a single container and save its definition in a YAML file:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run=client -- /bin/sh -c 'echo hello;sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox -o yaml --dry-run=client -- /bin/sh -c 'echo hello;sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 
@@ -58,7 +58,7 @@ kubectl delete po busybox
 Easiest way to do it is create a pod with a single container and save its definition in a YAML file:
 
 ```bash
-kubectl run web --image=nginx --restart=Never --port=80 --dry-run=client -o yaml > pod-init.yaml
+kubectl run web --image=nginx --port=80 --dry-run=client -o yaml > pod-init.yaml
 ```
 
 Copy/paste the container related values, so your final YAML should contain the volume and the initContainer:
@@ -135,7 +135,7 @@ kubectl apply -f pod-init.yaml
 kubectl get po -o wide
 
 # Execute wget
-kubectl run box --image=busybox --restart=Never -it --rm -- /bin/sh -c "wget -O- IP"
+kubectl run box --image=busybox -it --rm -- /bin/sh -c "wget -O- IP"
 
 # you can do some cleanup
 kubectl delete po box

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -10,9 +10,9 @@ kubernetes.io > Documentation > Concepts > Overview > [Labels and Selectors](htt
 <p>
 
 ```bash
-kubectl run nginx1 --image=nginx --restart=Never --labels=app=v1
-kubectl run nginx2 --image=nginx --restart=Never --labels=app=v1
-kubectl run nginx3 --image=nginx --restart=Never --labels=app=v1
+kubectl run nginx1 --image=nginx --labels=app=v1
+kubectl run nginx2 --image=nginx --labels=app=v1
+kubectl run nginx3 --image=nginx --labels=app=v1
 ```
 
 </p>

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -96,7 +96,7 @@ kubectl get cm configmap4 -o yaml
 
 ```bash
 kubectl create cm options --from-literal=var5=val5
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
 vi pod.yaml
 ```
 
@@ -140,7 +140,7 @@ kubectl exec -it nginx -- env | grep option # will show 'option=val5'
 
 ```bash
 kubectl create configmap anotherone --from-literal=var6=val6 --from-literal=var7=val7
-kubectl run --restart=Never nginx --image=nginx -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```
 
@@ -181,7 +181,7 @@ kubectl exec -it nginx -- env
 
 ```bash
 kubectl create configmap cmvolume --from-literal=var8=val8 --from-literal=var9=val9
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```
 
@@ -232,7 +232,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
 vi pod.yaml
 ```
 
@@ -267,7 +267,7 @@ status: {}
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
 vi pod.yaml
 ```
 
@@ -306,7 +306,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Assign 
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
+kubectl run nginx --image=nginx --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
 ```
 
 </p>
@@ -373,7 +373,7 @@ kubectl get secret mysecret2 -o jsonpath='{.data.username}{"\n"}' | base64 -d  #
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```
 
@@ -420,7 +420,7 @@ cat /etc/foo/username # shows admin
 
 ```bash
 kubectl delete po nginx
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```
 
@@ -515,14 +515,14 @@ kubectl create -f sa.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --serviceaccount=myuser -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx --serviceaccount=myuser -o yaml --dry-run=client > pod.yaml
 kubectl apply -f pod.yaml
 ```
 
 or you can add manually:
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run=client > pod.yaml
+kubectl run nginx --image=nginx -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```
 

--- a/e.observability.md
+++ b/e.observability.md
@@ -11,7 +11,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
 vi pod.yaml
 ```
 
@@ -96,7 +96,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --dry-run=client -o yaml --restart=Never --port=80 > pod.yaml
+kubectl run nginx --image=nginx --dry-run=client -o yaml --port=80 > pod.yaml
 vi pod.yaml
 ```
 
@@ -142,7 +142,7 @@ kubectl delete -f pod.yaml
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
+kubectl run busybox --image=busybox -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
 kubectl logs busybox -f # follow the logs
 ```
 
@@ -157,7 +157,7 @@ kubectl logs busybox -f # follow the logs
 <p>
 
 ```bash
-kubectl run busybox --restart=Never --image=busybox -- /bin/sh -c 'ls /notexist'
+kubectl run busybox --image=busybox -- /bin/sh -c 'ls /notexist'
 # show that there's an error
 kubectl logs busybox
 kubectl describe po busybox
@@ -173,7 +173,7 @@ kubectl delete po busybox
 <p>
 
 ```bash
-kubectl run busybox --restart=Never --image=busybox -- notexist
+kubectl run busybox --image=busybox -- notexist
 kubectl logs busybox # will bring nothing! container never started
 kubectl describe po busybox # in the events section, you'll see the error
 # also...

--- a/f.services.md
+++ b/f.services.md
@@ -7,7 +7,7 @@
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --port=80 --expose
+kubectl run nginx --image=nginx --port=80 --expose
 # observe that a pod as well as a service are created
 ```
 
@@ -35,7 +35,7 @@ kubectl get ep # endpoints
 
 ```bash
 kubectl get svc nginx # get the IP (something like 10.108.93.130)
-kubectl run busybox --rm --image=busybox -it --restart=Never -- sh
+kubectl run busybox --rm --image=busybox -it -- sh
 wget -O- IP:80
 exit
 ```
@@ -46,7 +46,7 @@ or
 
 ```bash
 IP=$(kubectl get svc nginx --template={{.spec.clusterIP}}) # get the IP (something like 10.108.93.130)
-kubectl run busybox --rm --image=busybox -it --restart=Never --env="IP=$IP" -- wget -O- $IP:80 --timeout 2
+kubectl run busybox --rm --image=busybox -it --env="IP=$IP" -- wget -O- $IP:80 --timeout 2
 # Tip: --timeout is optional, but it helps to get answer more quickly when connection fails (in seconds vs minutes)
 ```
 
@@ -128,7 +128,7 @@ kubectl create deploy foo --image=dgkanatsios/simpleapp --port=8080 --replicas=3
 
 ```bash
 kubectl get pods -l app=foo -o wide # 'wide' will show pod IPs
-kubectl run busybox --image=busybox --restart=Never -it --rm -- sh
+kubectl run busybox --image=busybox -it --rm -- sh
 wget -O- POD_IP:8080 # do not try with pod name, will not work
 # try hitting all IPs to confirm that hostname is different
 exit
@@ -159,7 +159,7 @@ kubectl get endpoints foo # you will see the IPs of the three replica nodes, lis
 
 ```bash
 kubectl get svc # get the foo service ClusterIP
-kubectl run busybox --image=busybox -it --rm --restart=Never -- sh
+kubectl run busybox --image=busybox -it --rm -- sh
 wget -O- foo:6262 # DNS works! run it many times, you'll see different pods responding
 wget -O- SERVICE_CLUSTER_IP:6262 # ClusterIP works as well
 # you can also kubectl logs on deployment pods to see the container logs
@@ -210,8 +210,8 @@ kubectl create -f policy.yaml
 
 # Check if the Network Policy has been created correctly
 # make sure that your cluster's network provider supports Network Policy (https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/#before-you-begin)
-kubectl run busybox --image=busybox --rm -it --restart=Never -- wget -O- http://nginx:80 --timeout 2                          # This should not work. --timeout is optional here. But it helps to get answer more quickly (in seconds vs minutes)
-kubectl run busybox --image=busybox --rm -it --restart=Never --labels=access=granted -- wget -O- http://nginx:80 --timeout 2  # This should be fine
+kubectl run busybox --image=busybox --rm -it -- wget -O- http://nginx:80 --timeout 2                          # This should not work. --timeout is optional here. But it helps to get answer more quickly (in seconds vs minutes)
+kubectl run busybox --image=busybox --rm -it --labels=access=granted -- wget -O- http://nginx:80 --timeout 2  # This should be fine
 ```
 
 </p>

--- a/g.state.md
+++ b/g.state.md
@@ -17,7 +17,7 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Configu
 Easiest way to do this is to create a template pod with:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run=client -- /bin/sh -c 'sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox -o yaml --dry-run=client -- /bin/sh -c 'sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 Copy paste the container definition and type the lines that have a comment in the end:
@@ -165,7 +165,7 @@ kubectl get pv # will show as 'Bound' as well
 Create a skeleton pod:
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -o yaml --dry-run=client -- /bin/sh -c 'sleep 3600' > pod.yaml
+kubectl run busybox --image=busybox -o yaml --dry-run=client -- /bin/sh -c 'sleep 3600' > pod.yaml
 vi pod.yaml
 ```
 
@@ -255,7 +255,7 @@ There are lots of different types per cloud provider (see here)[https://kubernet
 <p>
 
 ```bash
-kubectl run busybox --image=busybox --restart=Never -- sleep 3600
+kubectl run busybox --image=busybox -- sleep 3600
 kubectl cp busybox:etc/passwd ./passwd # kubectl cp command
 # previous command might report an error, feel free to ignore it since copy command works
 cat passwd


### PR DESCRIPTION
Before k8s 1.18, people would set the restart policy in their imperative commands to make `kubectl run` generate deployments, pods, or jobs depending on whether the restart policy was set to Always, OnFailure, or Never respectively. For example, `kubectl run nginx --image=nginx --restart=Always` created a deployment, and `kubectl run nginx --image=nginx --restart=Never` created a pod. The default behavior of `kubectl run` when a restart policy wasn't specified was also a deployment. You could even specify `--schedule` to create cronjobs too. With k8s 1.18 and above, `kubectl run` can now ONLY create pods, and people now have to use the `kubectl create` commands to create the other objects, including deployments. The bad thing about this is that in 1.18, `kubectl create deployment` doesn't support all the flags that `kubectl run` did, but with 1.19, some of these flags like `--port` and `--replicas` have been added to make the command more useful. With all of this in mind, this pull requests removes the `--restart=Never` trick where `kubectl run` is used, since we no longer need it for forcing the command to create pods. In other words, how this flag is being used is redundant and only serves to override the default restart policy of a pod, which is `Always` and not why it was included originally. I feel this change will make things more consistent now and in line with the exam, which is based on k8s 1.19+ now.

References:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#kubectl
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#feature-3
https://alexellisuk.medium.com/kubernetes-1-18-broke-kubectl-run-heres-what-to-do-about-it-2a88e5fb389a