### PR TITLE
Updated c.pod_design.md : more clear kubectl command

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -173,7 +173,7 @@ kubectl describe po nginx1 | grep -i 'annotations'
 
 # or
 
-kubectl get pods -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
+kubectl get po nginx1 -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
 ```
 
 As an alternative to using `| grep` you can use jsonPath like `kubectl get po nginx1 -o jsonpath='{.metadata.annotations}{"\n"}'`


### PR DESCRIPTION
Thank you for sharing awesome exercises 👍

I found that we can use the following `kubectl` command more clearly for the question. Because the question needs to check the annotation of `nginx1`.

>- Pod design (20%)
>    - Deployments
>      - Check the annotations for pod nginx1

The current `kubectl` command gets annotations for all pods. This is my example.

```sh
$ kubectl get pods -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
Name                       ANNOTATIONS
busybox                    <none>
busybox-1613632620-c6zfl   <none>
busybox-1613632680-qw9hx   <none>
busybox-1613632740-48cl6   <none>
nginx1                     my description
nginx2                     my description
nginx3                     my description
```

So I updated `kubectl` command. See below and diff.

## Before

```diff
kubectl describe po nginx1 | grep -i 'annotations'
  OR
-kubectl get pods -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
  OR
kubectl get po nginx1 -o jsonpath='{.metadata.annotations}{"\n"}'
```

## After

```diff
kubectl describe po nginx1 | grep -i 'annotations'
  OR
+kubectl get po nginx1 -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
  OR
kubectl get po nginx1 -o jsonpath='{.metadata.annotations}{"\n"}'
```

## Log

```sh
$ kubectl get po nginx1 -o custom-columns=Name:metadata.name,ANNOTATIONS:metadata.annotations.description
Name     ANNOTATIONS
nginx1   my description
```

Thank you :)