### PR TITLE
Updated g.state.md : fixed markdown link format

### DIFF
--- a/g.state.md
+++ b/g.state.md
@@ -244,7 +244,7 @@ kubectl get po busybox2 -o wide
 
 If they are on different nodes, you won't see the file, because we used the `hostPath` volume type.
 If you need to access the same files in a multi-node cluster, you need a volume type that is independent of a specific node.
-There are lots of different types per cloud provider (see here)[https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes], a general solution could be to use NFS.
+There are lots of different types per cloud provider [(see here)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes), a general solution could be to use NFS.
 
 </p>
 </details>


### PR DESCRIPTION
Thank you for sharing awesome exercises 👍

I found that markdown link (about **Persistent Volumes**) format is broken.

>- State Persistence (8%)
>    - Define volumes
>        - Create a second pod which is identical with the one you just created (you can easily do it by changing the 'name' property on pod.yaml). Connect to it and verify that '/etc/foo' contains the 'passwd' file. Delete pods to cleanup. Note: If you can't see the file from the second pod, can you figure out why? What would you do to fix that?

So I fixed markdown link format correctly.

Thank you :)