### PR TITLE
Using startingDeadlineSeconds instead of activeDeadlineSeconds

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -773,7 +773,7 @@ spec:
       creationTimestamp: null
       name: time-limited-job
     spec:
-      activeDeadlineSeconds: 17 # add this line
+      startingDeadlineSeconds: 17 # add this line
       template:
         metadata:
           creationTimestamp: null


### PR DESCRIPTION
**activeDeadlineSeconds** causes the following error:

error: error validating "cronjob2.yaml": error validating data: ValidationError(CronJob.spec): unknown field "activeDeadlineSeconds" in io.k8s.api.batch.v1beta1.CronJobSpec; if you choose to ignore these errors, turn validation off with --validate=false

Changing it to **startingDeadlineSeconds**