### PR TITLE
Updated c.pod_design.md : added status when pull error occurs

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -365,7 +365,7 @@ kubectl edit deploy nginx
 ```bash
 kubectl rollout status deploy nginx
 # or
-kubectl get po # you'll see 'ErrImagePull'
+kubectl get po # you'll see 'ErrImagePull' or 'ImagePullBackOff'
 ```
 
 </p>


### PR DESCRIPTION
Thank you for sharing awesome exercises 👍

I found that when we set wrong image name will get error `ErrImagePull` or `ImagePullBackOff` on exercise below.

>- Pod design (20%)
>    - Deployments
>      - Verify that something's wrong with the rollout

This is my sample logs.

```sh
$ kubectl get pods nginx-d645d84b6-ftbwc -w
NAME                    READY   STATUS         RESTARTS   AGE
nginx-d645d84b6-ftbwc   0/1     ImagePullBackOff   0          77s
nginx-d645d84b6-ftbwc   0/1     ErrImagePull       0          108s
nginx-d645d84b6-ftbwc   0/1     ImagePullBackOff   0          2m1s
nginx-d645d84b6-ftbwc   0/1     ErrImagePull       0          3m12s
nginx-d645d84b6-ftbwc   0/1     ImagePullBackOff   0          3m25s
nginx-d645d84b6-ftbwc   0/1     ErrImagePull       0          6m7s
nginx-d645d84b6-ftbwc   0/1     ImagePullBackOff   0          6m19s
```

And see reference below.

>ImagePullBackOff and ErrImagePull indicate that the image used by a container cannot be loaded from the image registry.
>https://cloud.google.com/kubernetes-engine/docs/troubleshooting#ImagePullBackOff

So I added error status `ImagePullBackOff`. It will be clear for the CKAD challenger 💡 

Thank you :)