### PR TITLE
Docs: add oneliner to generate numbered pods

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -13,6 +13,8 @@ kubernetes.io > Documentation > Concepts > Overview > [Labels and Selectors](htt
 kubectl run nginx1 --image=nginx --restart=Never --labels=app=v1
 kubectl run nginx2 --image=nginx --restart=Never --labels=app=v1
 kubectl run nginx3 --image=nginx --restart=Never --labels=app=v1
+# or
+for i in `seq 1 3`; do k run nginx$i --image=nginx -l app=v1 ; done
 ```
 
 </p>


### PR DESCRIPTION
This PR leverages bash oneliner to generate 3 pods.