### PR TITLE
Made mysecret2 value correspond to the previous operation.

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -355,13 +355,13 @@ kubectl create secret generic mysecret2 --from-file=username
 
 ```bash
 kubectl get secret mysecret2 -o yaml
-echo YWRtaW4K | base64 -d # on MAC it is -D, which decodes the value and shows 'admin'
+echo -n YWRtaW4= | base64 -d # on MAC it is -D, which decodes the value and shows 'admin'
 ```
 
 Alternative:
 
 ```bash
-kubectl get secret mysecret2 -o jsonpath='{.data.username}{"\n"}' | base64 -d  # on MAC it is -D
+kubectl get secret mysecret2 -o jsonpath='{.data.username}' | base64 -d  # on MAC it is -D
 ```
 
 </p>


### PR DESCRIPTION
At this PR (https://github.com/dgkanatsios/CKAD-exercises/pull/65), `-n` option was added to echo command in the first instruction of mysecret2 section, but subsequent instructions weren't updated so the base64 encoded value is not corresponding now.

* Changed base64 encoded value to correspond to the previous `echo -n admin > username` .
* Added `-n` to echo because echo without `-n` adds newline. It is not good for operations like value decoding.
* Removed the unnecessary newline from the `-o jsonpath` example.

Supporting operation logs.
```
ckad $ echo -n admin > username

ckad $ kubectl create secret generic mysecret2 --from-file=username
secret/mysecret2 created

ckad $ kubectl get secrets mysecret2 -o yaml
apiVersion: v1
data:
  username: YWRtaW4=  # <= this
kind: Secret
metadata:
  creationTimestamp: "2021-07-12T09:46:53Z"
  name: mysecret2
  namespace: default
  resourceVersion: "251434"
  uid: 86ee5e77-87b0-4d2a-a4f4-1cebbc74beb9
type: Opaque

ckad $ echo -n YWRtaW4= | base64 -d
admin  # (without newline)

ckad $ kubectl get secrets mysecret2 -o jsonpath="{.data.username}" | base64 -d
admin  # (without newline)
```