### PR TITLE
Use cronjob.spec.startingDeadlineSeconds instead of cronjob.spec.jobTemplate.spec.activeDeadlineSeconds

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -770,7 +770,7 @@ kubectl delete cj busybox
 kubectl create cronjob time-limited-job --image=busybox --restart=Never --dry-run=client --schedule="* * * * *" -o yaml -- /bin/sh -c 'date; echo Hello from the Kubernetes cluster' > time-limited-job.yaml
 vi time-limited-job.yaml
 ```
-Add cronjob.spec.jobTemplate.spec.activeDeadlineSeconds=17
+Add cronjob.spec.startingDeadlineSeconds=17
 
 ```bash
 apiVersion: batch/v1beta1
@@ -779,12 +779,12 @@ metadata:
   creationTimestamp: null
   name: time-limited-job
 spec:
+  startingDeadlineSeconds: 17  # add this line
   jobTemplate:
     metadata:
       creationTimestamp: null
       name: time-limited-job
     spec:
-      activeDeadlineSeconds: 17 # add this line
       template:
         metadata:
           creationTimestamp: null


### PR DESCRIPTION
This resolves #201. #175 should be closed as it is not a valid error. 

The [question](https://github.com/dgkanatsios/CKAD-exercises/blob/master/c.pod_design.md#create-a-cron-job-with-image-busybox-that-runs-every-minute-and-writes-date-echo-hello-from-the-kubernetes-cluster-to-standard-output-the-cron-job-should-be-terminated-if-it-takes-more-than-17-seconds-to-start-execution-after-its-schedule):-
> Create a cron job with image busybox that runs every minute and writes 'date; echo Hello from the Kubernetes cluster' to standard output. The cron job should be terminated if it takes more than 17 seconds to start execution after its schedule.

should not be solved by adding `cronjob.spec.jobTemplate.spec.activeDeadlineSeconds`.
The documentation for `activeDeadlineSeconds` states:-

> Specifies the duration in seconds relative to the startTime that **the job
     may be continuously active** before the system tries to terminate it; value
     must be positive integer. If a Job is suspended (at creation or through an
     update), this timer will effectively be stopped and reset when the Job is
     resumed again.

From the question:-
> takes more than 17 seconds **to start execution** after its schedule

`activeDeadlineSeconds` is counted after the job is active. So it is not correct.

The description for `cronjob.spec.startingDeadlineSeconds`:-
> Optional **deadline in seconds for starting the job if it misses scheduled
     time for any reason**. Missed jobs executions will be counted as failed ones.   

seems to answer the question more accurately.
