### PR TITLE
Add alternate way of checking Pod annotations

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -171,6 +171,10 @@ kubectl annotate po nginx{1..3} description='my description'
 <p>
 
 ```bash
+kubectl annotate pod nginx1 --list
+  
+# or
+
 kubectl describe po nginx1 | grep -i 'annotations'
 
 # or


### PR DESCRIPTION
Addition tested on K8s `v1.19.11` with kubectl `v1.22.1`