### PR TITLE
add unit to timeout wait

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -524,7 +524,7 @@ kubectl delete job pi
 OR 
 
 ```bash
-kubectl wait --for=condition=complete --timeout=300 job pi
+kubectl wait --for=condition=complete --timeout=300s job pi
 kubectl logs job/pi
 kubectl delete job pi
 ```


### PR DESCRIPTION
```
kubectl wait --for=condition=complete --timeout=300 job pi
```

Gives me the following error:

```
Error: invalid argument "300" for "--timeout" flag: time: missing unit in duration "300"
```

&nbsp;

```
debian:~$ kubectl version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2", GitTreeState:"clean", BuildDate:"2021-09-15T21:38:50Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2", GitTreeState:"clean", BuildDate:"2021-09-15T21:32:41Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
```