### PR TITLE
Remove --serviceaccount solution

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -533,13 +533,6 @@ kubectl create -f sa.yaml
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --serviceaccount=myuser -o yaml --dry-run=client > pod.yaml
-kubectl apply -f pod.yaml
-```
-
-or you can add manually:
-
-```bash
 kubectl run nginx --image=nginx --restart=Never -o yaml --dry-run=client > pod.yaml
 vi pod.yaml
 ```


### PR DESCRIPTION
Using the included solution based on `kubectl run` with the `--serviceaccount` option, I got the following message running on a k3s cluster:
`Flag --serviceaccount has been deprecated, has no effect and will be removed in 1.24.`
