### PR TITLE
Corrected grammar in Listing operator section 

### DIFF
--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -58,7 +58,7 @@ kubectl delete po busybox
 Easiest way to do it is create a pod with a single container and save its definition in a YAML file:
 
 ```bash
-kubectl run web --image=nginx --restart=Never --port=80 --dry-run=client -o yaml > pod-init.yaml
+kubectl run box --image=nginx --restart=Never --port=80 --dry-run=client -o yaml > pod-init.yaml
 ```
 
 Copy/paste the container related values, so your final YAML should contain the volume and the initContainer:

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -780,6 +780,11 @@ kubectl create cronjob busybox --image=busybox --schedule="*/1 * * * *" -- /bin/
 </details>
 
 ### See its logs and delete it
+```bash
+kubectl get po   # copy the container just created
+kubectl logs <container> # you will see the date and message 
+kubectl delete cj busybox --force #cj stands for cronjob and --force to delete immediately 
+```
 
 <details><summary>show</summary>
 <p>

--- a/f.services.md
+++ b/f.services.md
@@ -170,7 +170,7 @@ kubectl get endpoints foo # you will see the IPs of the three replica pods, list
 kubectl get svc # get the foo service ClusterIP
 kubectl run busybox --image=busybox -it --rm --restart=Never -- sh
 wget -O- foo:6262 # DNS works! run it many times, you'll see different pods responding
-wget -O- SERVICE_CLUSTER_IP:6262 # ClusterIP works as well
+wget -O- <SERVICE_CLUSTER_IP>:6262 # ClusterIP works as well
 # you can also kubectl logs on deployment pods to see the container logs
 kubectl delete svc foo
 kubectl delete deploy foo

--- a/f.services.md
+++ b/f.services.md
@@ -136,8 +136,8 @@ kubectl label deployment foo --overwrite app=foo
 ```bash
 kubectl get pods -l app=foo -o wide # 'wide' will show pod IPs
 kubectl run busybox --image=busybox --restart=Never -it --rm -- sh
-wget -O- POD_IP:8080 # do not try with pod name, will not work
-# try hitting all IPs to confirm that hostname is different
+wget -O- <POD_IP>:8080 # do not try with pod name, will not work
+# try hitting all IPs generated after running 1st command to confirm that hostname is different
 exit
 # or
 kubectl get po -o wide -l app=foo | awk '{print $6}' | grep -v IP | xargs -L1 -I '{}' kubectl run --rm -ti tmp --restart=Never --image=busybox -- wget -O- http://\{\}:8080

--- a/g.state.md
+++ b/g.state.md
@@ -58,6 +58,15 @@ spec:
   - name: myvolume #
     emptyDir: {} #
 ```
+In case you forget to add ```bash -- /bin/sh -c 'sleep 3600'``` in template pod create command, you can include command field in config file
+
+```YAML
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    command: ["/bin/sh", "-c", "sleep 3600"]
+```
 
 Connect to the second container:
 

--- a/i.crd.md
+++ b/i.crd.md
@@ -96,9 +96,9 @@ Use singular, plural and short forms
 
 ```bash
 kubectl get operators
-
+or
 kubectl get operator
-
+or
 kubectl get op
 ```
 


### PR DESCRIPTION
$ alias k=kubectl

 % k get operators 
NAME              AGE
operator-sample   11s
 % k get operator 
NAME              AGE
operator-sample   15s
 % k get op      
NAME              AGE
operator-sample   26s

above command generates the same o/p , updated version should be 
kubectl get operators
or
kubectl get operator
or
kubectl get op
