### PR TITLE
Update d.configuration.md

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -316,18 +316,6 @@ kubernetes.io > Documentation > Tasks > Configure Pods and Containers > [Assign 
 <p>
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
-```
-
-Note: Use of `--requests` and `--limits` flags in the imperative `run` command is deprecated as of 1.21 K8s version and will be removed in the future. Instead, use `kubectl set resources` command in combination with `kubectl run --dry-run=client -o yaml ...` as shown below.
-
-Alternative using `set resources` in combination with imperative `run` command:
-
-```bash
-kubectl run nginx --image=nginx --restart=Never --dry-run=client -o yaml | kubectl set resources -f - --requests=cpu=100m,memory=256Mi --limits=cpu=200m,memory=512Mi --local -o yaml > nginx-pod.yml
-```
-
-```bash
 kubectl create -f nginx-pod.yml
 ```
 


### PR DESCRIPTION
these parameters are deprecated and has no effect.
```
k8s@terminal:~$ kubectl run nginx --image=nginx --restart=Never --requests='cpu=100m,memory=256Mi' --limits='cpu=200m,memory=512Mi'
Flag --requests has been deprecated, has no effect and will be removed in 1.24.
Flag --limits has been deprecated, has no effect and will be removed in 1.24.
```