### PR TITLE
Add exercise for canary deployment

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,7 +520,7 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
-### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
+### Implement canary deployment by running two instances of nginx marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
 
 <details><summary>show</summary>
 <p>
@@ -546,18 +546,13 @@ spec:
         version: v1
     spec:
       containers:
-      - name: my-app
-        image: ubuntu
-        command:
-        - /bin/sh
-        - -c
-        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+      - name: nginx
+        image: nginx
         ports:
-        - name: http
-          containerPort: 80
+        - containerPort: 80
         volumeMounts:
         - name: workdir
-          mountPath: "/work-dir"
+          mountPath: /usr/share/nginx/html
       initContainers:
       - name: install
         image: busybox:1.28
@@ -606,6 +601,7 @@ metadata:
   labels:
     app: my-app
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: my-app
@@ -617,18 +613,13 @@ spec:
         version: v2
     spec:
       containers:
-      - name: my-app
-        image: ubuntu
-        command:
-        - /bin/sh
-        - -c
-        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+      - name: nginx
+        image: nginx
         ports:
-        - name: http
-          containerPort: 80
+        - containerPort: 80
         volumeMounts:
         - name: workdir
-          mountPath: "/work-dir"
+          mountPath: /usr/share/nginx/html
       initContainers:
       - name: install
         image: busybox:1.28

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,6 +520,157 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
+### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio.
+
+<details><summary>show</summary>
+<p>
+
+Deploy 3 replicas of v1:
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1
+    spec:
+      containers:
+      - name: my-app
+        image: ubuntu
+        command:
+        - /bin/sh
+        - -c
+        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+        ports:
+        - name: http
+          containerPort: 80
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - /bin/sh
+        - -c
+        - "echo version-1 > /work-dir/index.html"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      volumes:
+      - name: workdir
+        emptyDir: {}
+```
+
+Create the service:
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-svc
+  labels:
+    app: my-app
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    app: my-app
+```
+
+Test if the deployment was successful:
+```bash
+curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}")
+version-1
+```
+
+Deploy 1 replica of v2:
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v2
+    spec:
+      containers:
+      - name: my-app
+        image: ubuntu
+        command:
+        - /bin/sh
+        - -c
+        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+        ports:
+        - name: http
+          containerPort: 80
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - /bin/sh
+        - -c
+        - "echo version-2 > /work-dir/index.html"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      volumes:
+      - name: workdir
+        emptyDir: {}
+```
+
+Observe that calling the ip exposed by the service the requests are load balanced across the two versions:
+```bash
+while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+version-1
+version-1
+version-1
+version-2
+version-2
+version-1
+```
+
+If the v2 is stable, scale it up to 4 replicas and shoutsown the v1:
+```
+kubectl scale --replicas=4 deploy my-app-v2
+kubectl delete deploy my-app-v1
+while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+version-2
+version-2
+version-2
+version-2
+version-2
+version-2
+```
+
+</p>
+</details>
+
 ## Jobs
 
 ### Create a job named pi with image perl that runs the command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,7 +520,7 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
-### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio.
+### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
 
 <details><summary>show</summary>
 <p>

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -655,7 +655,7 @@ version-2
 version-1
 ```
 
-If the v2 is stable, scale it up to 4 replicas and shoutsown the v1:
+If the v2 is stable, scale it up to 4 replicas and shoutdown the v1:
 ```
 kubectl scale --replicas=4 deploy my-app-v2
 kubectl delete deploy my-app-v1


### PR DESCRIPTION
The [CKAD Curriculum](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_v1.23.pdf) (v1.23) mentions between the domains of the exam the capacity to "Use Kubernetes primitives to implement common deployment strategies (e.g. blue/green or canary)": I propose to add a simple exercise to implement natively (i.e. without an ingress controller or service mesh) a canary deployment. It seems that a similar question came out in a candidate's exam: see issue #233.