### PR TITLE
Add exercises for managing container images

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,7 +520,7 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
-### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
+### Implement canary deployment by running two instances of nginx marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
 
 <details><summary>show</summary>
 <p>
@@ -546,18 +546,13 @@ spec:
         version: v1
     spec:
       containers:
-      - name: my-app
-        image: ubuntu
-        command:
-        - /bin/sh
-        - -c
-        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+      - name: nginx
+        image: nginx
         ports:
-        - name: http
-          containerPort: 80
+        - containerPort: 80
         volumeMounts:
         - name: workdir
-          mountPath: "/work-dir"
+          mountPath: /usr/share/nginx/html
       initContainers:
       - name: install
         image: busybox:1.28
@@ -606,6 +601,7 @@ metadata:
   labels:
     app: my-app
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: my-app
@@ -617,18 +613,13 @@ spec:
         version: v2
     spec:
       containers:
-      - name: my-app
-        image: ubuntu
-        command:
-        - /bin/sh
-        - -c
-        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+      - name: nginx
+        image: nginx
         ports:
-        - name: http
-          containerPort: 80
+        - containerPort: 80
         volumeMounts:
         - name: workdir
-          mountPath: "/work-dir"
+          mountPath: /usr/share/nginx/html
       initContainers:
       - name: install
         image: busybox:1.28

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,6 +520,157 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
+### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio.
+
+<details><summary>show</summary>
+<p>
+
+Deploy 3 replicas of v1:
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1
+    spec:
+      containers:
+      - name: my-app
+        image: ubuntu
+        command:
+        - /bin/sh
+        - -c
+        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+        ports:
+        - name: http
+          containerPort: 80
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - /bin/sh
+        - -c
+        - "echo version-1 > /work-dir/index.html"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      volumes:
+      - name: workdir
+        emptyDir: {}
+```
+
+Create the service:
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-svc
+  labels:
+    app: my-app
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    app: my-app
+```
+
+Test if the deployment was successful:
+```bash
+curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}")
+version-1
+```
+
+Deploy 1 replica of v2:
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v2
+    spec:
+      containers:
+      - name: my-app
+        image: ubuntu
+        command:
+        - /bin/sh
+        - -c
+        - "apt update && apt install -y python3 && python3 -m http.server 80 --directory /work-dir"
+        ports:
+        - name: http
+          containerPort: 80
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command:
+        - /bin/sh
+        - -c
+        - "echo version-2 > /work-dir/index.html"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+      volumes:
+      - name: workdir
+        emptyDir: {}
+```
+
+Observe that calling the ip exposed by the service the requests are load balanced across the two versions:
+```bash
+while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+version-1
+version-1
+version-1
+version-2
+version-2
+version-1
+```
+
+If the v2 is stable, scale it up to 4 replicas and shoutsown the v1:
+```
+kubectl scale --replicas=4 deploy my-app-v2
+kubectl delete deploy my-app-v1
+while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+version-2
+version-2
+version-2
+version-2
+version-2
+version-2
+```
+
+</p>
+</details>
+
 ## Jobs
 
 ### Create a job named pi with image perl that runs the command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -520,7 +520,7 @@ kubectl delete deploy/nginx hpa/nginx
 </p>
 </details>
 
-### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio.
+### Implement canary deployment by running two instances of a simple http python server marked as version=v1 and version=v2 so that the load is balanced at 75%-25% ratio
 
 <details><summary>show</summary>
 <p>

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -655,7 +655,7 @@ version-2
 version-1
 ```
 
-If the v2 is stable, scale it up to 4 replicas and shoutsown the v1:
+If the v2 is stable, scale it up to 4 replicas and shoutdown the v1:
 ```
 kubectl scale --replicas=4 deploy my-app-v2
 kubectl delete deploy my-app-v1

--- a/j.podman.md
+++ b/j.podman.md
@@ -90,19 +90,32 @@ Hello, World!
 </p>
 </details>
 
-### Tag the image with ip and port of a local private registry and then push the image to this registry. Verify that the registry contains the pushed image and that you can pull it
+### Tag the image with ip and port of a local private registry and then push the image to this registry
 
 <details><summary>show</summary>
 <p>
+
+> Note: Some small distributions of Kubernetes (such as [microk8s](https://microk8s.io/docs/registry-built-in)) has a built-in registry you can use for this exercise. If this is not your case, you'll have to setup it on your own.
 
 ```bash
 :~$ podman tag localhost/simpleapp $registry_ip:5000/simpleapp
 
 :~$ podman push $registry_ip:5000/simpleapp
+```
 
+</p>
+</details>
+
+ Verify that the registry contains the pushed image and that you can pull it
+
+<details><summary>show</summary>
+<p>
+
+```bash
 :~$ curl http://$registry_ip:5000/v2/_catalog
 {"repositories":["simpleapp"]}
 
+# remove the image already present
 :~$ podman rmi $registry_ip:5000/simpleapp
 
 :~$ podman pull $registry_ip:5000/simpleapp

--- a/j.podman.md
+++ b/j.podman.md
@@ -1,0 +1,153 @@
+# Define, build and modify container images
+
+- Note: The topic is part of the new CKAD syllabus. Here are a few examples of using **podman** to manage the life cycle of container images. The use of **docker** had been the industry standard for many years, but now large companies like [Red Hat](https://www.redhat.com/en/blog/say-hello-buildah-podman-and-skopeo) are moving to a new suite of open source tools: podman, skopeo and buildah. Also Kubernetes has moved in this [direction](https://kubernetes.io/blog/2022/02/17/dockershim-faq/). In particular, `podman` is meant to be the replacement of the `docker` command: so it makes sense to get familiar with it, although they are quite interchangeable considering that they use the same syntax.
+
+## Podman basics
+
+### Create a Dockerfile to deploy an Apache HTTP Server which hosts a custom main page
+
+<details><summary>show</summary>
+<p>
+
+```Dockerfile
+FROM httpd:2.4
+RUN echo "Hello, World!" /usr/local/apache2/htdocs/index.html
+```
+
+</p>
+</details>
+
+### Build and see how many layers the image consists of
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman build -t simpleapp .
+STEP 1/2: FROM httpd:2.4
+STEP 2/2: RUN echo "Hello, World!" > /usr/local/apache2/htdocs/index.html
+COMMIT simpleapp
+--> ef4b14a72d0
+Successfully tagged localhost/simpleapp:latest
+ef4b14a72d02ae0577eb0632d084c057777725c279e12ccf5b0c6e4ff5fd598b
+
+:~$ podman images
+REPOSITORY               TAG         IMAGE ID      CREATED        SIZE
+localhost/simpleapp      latest      ef4b14a72d02  8 seconds ago  148 MB
+docker.io/library/httpd  2.4         98f93cd0ec3b  7 days ago     148 MB
+
+:~$ podman image tree localhost/simpleapp:latest
+Image ID: ef4b14a72d02
+Tags:     [localhost/simpleapp:latest]
+Size:     147.8MB
+Image Layers
+├── ID: ad6562704f37 Size:  83.9MB
+├── ID: c234616e1912 Size: 3.072kB
+├── ID: c23a797b2d04 Size: 2.721MB
+├── ID: ede2e092faf0 Size: 61.11MB
+├── ID: 971c2cdf3872 Size: 3.584kB Top Layer of: [docker.io/library/httpd:2.4]
+└── ID: 61644e82ef1f Size: 6.144kB Top Layer of: [localhost/simpleapp:latest]
+```
+
+</p>
+</details>
+
+### Run the image locally, inspect its status and logs, finally test that it responds as expected
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman run -d --name test -p 8080:80 localhost/simpleapp
+2f3d7d613ea6ba19703811d30704d4025123c7302ff6fa295affc9bd30e532f8
+
+:~$ podman ps
+CONTAINER ID  IMAGE                       COMMAND           CREATED        STATUS            PORTS                 NAMES
+2f3d7d613ea6  localhost/simpleapp:latest  httpd-foreground  5 seconds ago  Up 6 seconds ago  0.0.0.0:8080->80/tcp  test
+
+:~$ podman logs test
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.0.2.100. Set the 'ServerName' directive globally to suppress this message
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.0.2.100. Set the 'ServerName' directive globally to suppress this message
+[Sat Jun 04 16:15:38.071377 2022] [mpm_event:notice] [pid 1:tid 139756978220352] AH00489: Apache/2.4.53 (Unix) configured -- resuming normal operations
+[Sat Jun 04 16:15:38.073570 2022] [core:notice] [pid 1:tid 139756978220352] AH00094: Command line: 'httpd -D FOREGROUND'
+
+:~$ curl 0.0.0.0:8080
+Hello, World!
+```
+
+</p>
+</details>
+
+### Run a command inside the pod to print out the index.html file
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman exec -it test cat /usr/local/apache2/htdocs/index.html
+Hello, World!
+```
+</p>
+</details>
+
+### Tag the image with ip and port of a local private registry and then push the image to this registry. Verify that the registry contains the pushed image and that you cann pull it
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman tag localhost/simpleapp $registry_ip:5000/simpleapp
+
+:~$ podman push $registry_ip:5000/simpleapp
+
+:~$ curl http://$registry_ip:5000/v2/_catalog
+{"repositories":["simpleapp"]}
+
+:~$ podman rmi $registry_ip:5000/simpleapp
+
+:~$ podman pull $registry_ip:5000/simpleapp
+Trying to pull 10.152.183.13:5000/simpleapp:latest...
+Getting image source signatures
+Copying blob 643ea8c2c185 skipped: already exists
+Copying blob 972107ece720 skipped: already exists
+Copying blob 9857eeea6120 skipped: already exists
+Copying blob 93859aa62dbd skipped: already exists
+Copying blob 8e47efbf2b7e skipped: already exists
+Copying blob 42e0f5a91e40 skipped: already exists
+Copying config ef4b14a72d done
+Writing manifest to image destination
+Storing signatures
+ef4b14a72d02ae0577eb0632d084c057777725c279e12ccf5b0c6e4ff5fd598b
+```
+
+</p>
+</details>
+
+### Run a pod with the image pushed to the registry
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ kubectl run simpleapp --image=$registry_ip:5000/simpleapp --port=80
+
+:~$ curl ${kubectl get pods simpleapp -o jsonpath='{.status.podIP}'}
+Hello, World!
+```
+
+</p>
+</details>
+
+### Clean up all the images and containers
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman rm --all --force
+:~$ podman rmi --all
+:~$ kubectl delete pod simpleapp
+```
+
+</p>
+</details>

--- a/j.podman.md
+++ b/j.podman.md
@@ -153,10 +153,11 @@ Hello, World!
 
 ### Log into a remote registry server and then read the credentials from the default file
 
-> Note: The two most used container registry servers with a free plan are [DockerHub](https://hub.docker.com/) and [Quay.io](https://quay.io/).
 
 <details><summary>show</summary>
 <p>
+
+> Note: The two most used container registry servers with a free plan are [DockerHub](https://hub.docker.com/) and [Quay.io](https://quay.io/).
 
 ```bash
 :~$ podman login --username $YOUR_USER --password $YOUR_PWD docker.io

--- a/j.podman.md
+++ b/j.podman.md
@@ -153,6 +153,8 @@ Hello, World!
 
 ### Log into a remote registry server and then read the credentials from the default file
 
+> Note: The two most used container registry servers with a free plan are [DockerHub](https://hub.docker.com/) and [Quay.io](https://quay.io/).
+
 <details><summary>show</summary>
 <p>
 

--- a/j.podman.md
+++ b/j.podman.md
@@ -90,7 +90,7 @@ Hello, World!
 </p>
 </details>
 
-### Tag the image with ip and port of a local private registry and then push the image to this registry. Verify that the registry contains the pushed image and that you cann pull it
+### Tag the image with ip and port of a local private registry and then push the image to this registry. Verify that the registry contains the pushed image and that you can pull it
 
 <details><summary>show</summary>
 <p>

--- a/j.podman.md
+++ b/j.podman.md
@@ -95,7 +95,7 @@ Hello, World!
 <details><summary>show</summary>
 <p>
 
-> Note: Some small distributions of Kubernetes (such as [microk8s](https://microk8s.io/docs/registry-built-in)) has a built-in registry you can use for this exercise. If this is not your case, you'll have to setup it on your own.
+> Note: Some small distributions of Kubernetes (such as [microk8s](https://microk8s.io/docs/registry-built-in)) have a built-in registry you can use for this exercise. If this is not your case, you'll have to setup it on your own.
 
 ```bash
 :~$ podman tag localhost/simpleapp $registry_ip:5000/simpleapp

--- a/j.podman.md
+++ b/j.podman.md
@@ -90,7 +90,7 @@ Hello, World!
 </p>
 </details>
 
-### Tag the image with ip and port of a local private registry and then push the image to this registry
+### Tag the image with ip and port of a private local registry and then push the image to this registry
 
 <details><summary>show</summary>
 <p>
@@ -146,6 +146,62 @@ ef4b14a72d02ae0577eb0632d084c057777725c279e12ccf5b0c6e4ff5fd598b
 
 :~$ curl ${kubectl get pods simpleapp -o jsonpath='{.status.podIP}'}
 Hello, World!
+```
+
+</p>
+</details>
+
+### Log into a remote registry server and then read the credentials from the default file
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ podman login --username $YOUR_USER --password $YOUR_PWD docker.io
+:~$ cat ${XDG_RUNTIME_DIR}/containers/auth.json
+{
+        "auths": {
+                "docker.io": {
+                        "auth": "Z2l1bGl0JLSGtvbkxCcX1xb617251xh0x3zaUd4QW45Q3JuV3RDOTc="
+                }
+        }
+}
+```
+
+</p>
+</details>
+
+### Create a secret both from existing login credentials and from the CLI
+
+<details><summary>show</summary>
+<p>
+
+```bash
+:~$ kubectl create secret generic mysecret --from-file=.dockerconfigjson=${XDG_RUNTIME_DIR}/containers/auth.json --type=kubernetes.io/dockeconfigjson
+secret/mysecret created
+:~$ kubectl create secret docker-registry mysecret2 --docker-server=https://index.docker.io/v1/ --docker-username=$YOUR_USR --docker-password=$YOUR_PWD
+secret/mysecret2 created
+```
+
+</p>
+</details>
+
+### Create the manifest for a Pod that uses one of the two secrets just created to pull an image hosted on the relative private remote registry
+
+<details><summary>show</summary>
+<p>
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: private-reg
+spec:
+  containers:
+  - name: private-reg-container
+    image: $YOUR_PRIVATE_IMAGE
+  imagePullSecrets:
+  - name: mysecret
 ```
 
 </p>


### PR DESCRIPTION
A new topic in the exam [syllabus](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_v1.23.pdf) (v1.23) deals with the ability to *define, build and modify container images*. I propose to add a set of exercises to cover this topic by using `podman` since also the LFD259 course uses it in the labs in favour of or besides`docker`. I'm not really sure if both or just of the two commands are available in the exam environment, since I have to still sit the exam, but anyway they are quite interchangeable as stated in the little intro to the exercises.