### PR TITLE
improve the answer to the 4th question of the observability section

### DIFF
--- a/e.observability.md
+++ b/e.observability.md
@@ -148,7 +148,7 @@ LAST SEEN   TYPE      REASON      OBJECT              MESSAGE
 collect failed pods namespace by namespace
 
 ```sh
-kubectl get events -A | grep -i "Liveness probe failed" | awk '{print $1,$5}'
+kubectl get events -o json | jq -r '.items[] | select(.message | contains("failed liveness probe")).involvedObject | .namespace + "/" + .name'
 ```
 
 </p>


### PR DESCRIPTION
According to the 4th question, the output should be in the format of `<namespace>/<pod name>`. The previous `awk` solution does not exactly follow the format, and the `kubectl get events -A` could output the duplicated events if some Pods are restarting over and over again due to the different `restartPolicy`s.