### PR TITLE
Specified the perl image version in Jobs exercise - to avoid errors

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -664,7 +664,7 @@ version-2
 
 ## Jobs
 
-### Create a job named pi with image perl that runs the command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"
+### Create a job named pi with image perl:5.34 that runs the command with arguments "perl -Mbignum=bpi -wle 'print bpi(2000)'"
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION

The usage of the latest perl image version in [this](https://github.com/dgkanatsios/CKAD-exercises/blob/main/c.pod_design.md#create-a-job-named-pi-with-image-perl-that-runs-the-command-with-arguments-perl--mbignumbpi--wle-print-bpi2000) exercise leads to the following error:

``` Can't use an undefined value as an ARRAY reference at /usr/local/lib/perl5/5.36.0/Math/BigInt/Calc.pm line 1049.```

I modified the description of the exercise to point to the image version that is mentioned in the solution.