### PR TITLE
fix command in Secret section

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -452,7 +452,7 @@ status: {}
 
 ```bash
 kubectl create -f pod.yaml
-kubectl exec -it nginx /bin/bash
+kubectl exec -it nginx -- /bin/bash
 ls /etc/foo  # shows username
 cat /etc/foo/username # shows admin
 ```


### PR DESCRIPTION
## WHAT
Added `--` for the command.

## WHY
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.