### PR TITLE
update c.pod-design.md : test deployment from within a pod

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -586,10 +586,12 @@ spec:
     app: my-app
 ```
 
-Test if the deployment was successful:
-```bash
-curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}")
-version-1
+Test if the deployment was successful from within a Pod:
+```
+# run a wget to the Service my-app-svc
+  kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox --command -- wget -qO- my-app-svc
+
+  version-1
 ```
 
 Deploy 1 replica of v2:
@@ -636,8 +638,13 @@ spec:
 ```
 
 Observe that calling the ip exposed by the service the requests are load balanced across the two versions:
-```bash
-while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+```
+# run a busyBox pod 
+kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox sh
+# Once in the busybox shell run the following command 
+# This will make a wget call to the service my-app-svc and print out the version of the pod it reached.
+while sleep 1; do wget -qO- my-app-svc; done
+
 version-1
 version-1
 version-1

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -589,9 +589,9 @@ spec:
 Test if the deployment was successful from within a Pod:
 ```
 # run a wget to the Service my-app-svc
-  kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox --command -- wget -qO- my-app-svc
+kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox --command -- wget -qO- my-app-svc
 
-  version-1
+version-1
 ```
 
 Deploy 1 replica of v2:

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -639,11 +639,8 @@ spec:
 
 Observe that calling the ip exposed by the service the requests are load balanced across the two versions:
 ```
-# run a busyBox pod 
-kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox sh
-# Once in the busybox shell run the following command 
-# This will make a wget call to the service my-app-svc and print out the version of the pod it reached.
-while sleep 1; do wget -qO- my-app-svc; done
+# run a busyBox pod that will make a wget call to the service my-app-svc and print out the version of the pod it reached.
+kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox -- /bin/sh -c 'while sleep 1; do wget -qO- my-app-svc; done'
 
 version-1
 version-1


### PR DESCRIPTION
Hello, 

In the Pod Design section in the last exercice : https://github.com/dgkanatsios/CKAD-exercises/blob/main/c.pod_design.md#implement-canary-deployment-by-running-two-instances-of-nginx-marked-as-versionv1-and-versionv2-so-that-the-load-is-balanced-at-75-25-ratio 

In the solution it is needed to check if the deployment was successful by using the command : 
`curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}")` , however this command does not work if you don't have a nodePort Service to expose it to your local machine.

My suggestion is to test the deployment from whitin a pod by using a busyBox image and the `wget` command.

This is also a solution to the issue : https://github.com/dgkanatsios/CKAD-exercises/issues/281

