### PR TITLE
Update info about allowed resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 # CKAD Exercises
 
-A set of exercises that helped me prepare for the [Certified Kubernetes Application Developer](https://www.cncf.io/certification/ckad/) exam, offered by the Cloud Native Computing Foundation, organized by curriculum domain. They may as well serve as learning and practicing with Kubernetes.
+A set of exercises that helped me prepare for the [Certified Kubernetes Application Developer](https://www.cncf.io/certification/ckad/) exam, offered by the Cloud Native Computing Foundation, organized by curriculum domain.
+They may as well serve as learning and practicing with Kubernetes.
 
-During the exam, you are allowed to keep only one other browser tab open to refer to official documentation. Make a mental note of the breadcrumb at the start of the excercise section, to quickly locate the relevant document in kubernetes.io. It is recommended that you read the official documents before attempting exercises below it.
+Make a mental note of the breadcrumb at the start of the excercise section, to quickly locate the relevant document in kubernetes.io.
+It is recommended that you read the official documents before attempting exercises below it.
+During the exam, you are only allowed to refer to official documentation from a browser window within the exam VM.
+A Quick Reference box will contain helpful links for each exam exercise as well.
 
 ## Contents
 


### PR DESCRIPTION
As of June 2022, personal browser bookmarks are not allowed anymore. The browser within the exam environment must be used to access the K8s docs.

> Personal browser bookmarks (such as bookmarked links to YAML files) will not be accessible within the PSI Secure Browser.
Links to CNCF documentation, considered most helpful to complete your work, have been added to a Quick Reference box within each item’s instructions. Access to [published Resources Allowed](https://docs.linuxfoundation.org/tc-docs/certification/certification-resources-allowed#certified-kubernetes-administrator-cka-and-certified-kubernetes-application-developer-ckad) will still be permitted within the Exam Environment.

https://training.linuxfoundation.org/bridge-migration-2021/

This change is also reflected in the certification documentation: 

https://docs.linuxfoundation.org/tc-docs/certification/certification-resources-allowed#certified-kubernetes-administrator-cka-and-certified-kubernetes-application-developer-ckad