### PR TITLE
Add double quotation mark

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -335,10 +335,10 @@ spec:
     resources:
       requests:
         memory: "256Mi"
-        cpu: 100m
+        cpu: "100m"
       limits:    
         memory: "512Mi"
-        cpu: 200m
+        cpu: "200m"
   dnsPolicy: ClusterFirst
   restartPolicy: Always
 status: {}


### PR DESCRIPTION
At official kubernetes webpages, I can see double quotation marks at cpu resources. So I add this,

example at kubernetes websites:

apiVersion: v1
kind: Pod
metadata:
  name: frontend
spec:
  containers:
  - name: app image: images.my-company.example/app:v4 resources: requests: memory: "64Mi" cpu: "250m" limits: memory: "128Mi" cpu: "500m"
  - name: log-aggregator image: images.my-company.example/log-aggregator:v6 resources: requests: memory: "64Mi" cpu: "250m" limits:
        memory: "128Mi"
        cpu: "500m"