### PR TITLE
refactor: simplify explanation for exposed ports for httpGet in probes

### DIFF
--- a/e.observability.md
+++ b/e.observability.md
@@ -114,12 +114,10 @@ spec:
     imagePullPolicy: IfNotPresent
     name: nginx
     resources: {}
-    ports:
-      - containerPort: 80 # Note: Readiness probes runs on the container during its whole lifecycle. Since nginx exposes 80, containerPort: 80 is not required for readiness to work.
     readinessProbe: # declare the readiness probe
       httpGet: # add this line
         path: / #
-        port: 80 #
+        port: 80 # Since nginx exposes 80, exposing containerPort: 80 is not required for readiness to work.
   dnsPolicy: ClusterFirst
   restartPolicy: Never
 status: {}


### PR DESCRIPTION
I think there is no reason to illustrate an exposed containerport 80, since it would obfuscate that there is no reason for this port to be exposed.