### PR TITLE
Fix pod on control-pane

### DIFF
--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -263,8 +263,8 @@ kind: Pod
 metadata:
   name: frontend
 spec:
-  image:
-    name: nginx
+  containers:
+  - name: nginx
     image: nginx
   tolerations:
   - key: "tier"


### PR DESCRIPTION
Fix pod yaml for https://github.com/dgkanatsios/CKAD-exercises/blob/main/c.pod_design.md#create-a-pod-that-will-be-placed-on-node-controlplane-use-nodeselector-and-tolerations

Error from server (BadRequest): error when creating "pod.yaml": Pod in version "v1" cannot be handled as a Pod: strict decoding error: unknown field "spec.image"