### PR TITLE
Update missing namespace field in d.configuration.md

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -449,6 +449,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: my-rq
+  namespace: one
 spec:
   hard:
     requests.cpu: "1"


### PR DESCRIPTION
namespace field missing in YAML file. which will make the resource to be deployed on the default namespace instead of the indented one