### PR TITLE
Update Dockerfile in j.podman.md

### DIFF
--- a/j.podman.md
+++ b/j.podman.md
@@ -10,7 +10,7 @@
 <p>
 
 ```Dockerfile
-FROM httpd:2.4
+FROM docker.io/httpd:2.4
 RUN echo "Hello, World!" > /usr/local/apache2/htdocs/index.html
 ```
 


### PR DESCRIPTION
`podman` no longer supports `docker.io` as a default registry, so the `Dockerfile` should mention it explicitly.

The old behaviour can be restored by adding a config to `/etc/containers/registries.conf`:

```sh
unqualified-search-registries = ["docker.io"]
```

but I believe that specifying a fully-qualified name is a more pragmatic way to go.

The solution comes from this [SE post](https://unix.stackexchange.com/a/701785).  
Also see the related documentation for [`containers-registries.conf`](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#note-risk-of-using-unqualified-image-names)