### PR TITLE
fix(configuration): fix bash commands in secrets question

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -732,7 +732,8 @@ kubectl exec -it nginx -- env | grep USERNAME | cut -d '=' -f 2 # will show 'adm
 
 ```bash
 export ns="-n secret-ops"
-k create secret generic ext-service-secret -n secret-ops --from-literal=API_KEY=LmLHbYhsgWZwNifiqaRorH8T $do > sc.yaml
+export do="--dry-run=client -oyaml"
+k create secret generic ext-service-secret --from-literal=API_KEY=LmLHbYhsgWZwNifiqaRorH8T $ns $do > sc.yaml
 k apply -f sc.yaml
 ```
 


### PR DESCRIPTION
The Secrets question

> Create a Secret named 'ext-service-secret' in the namespace 'secret-ops'. Then, provide the key-value pair API_KEY=LmLHbYhsgWZwNifiqaRorH8T as literal.

had some issues with the bash commands shown:

1. `$ns` was defined but not used; instead, `-n secret-ops` was reiterated in the command.
2. `$do` was not defined but used. Unless you read the really out of context tip at the top of the page and remembered it, you would know how to define `$do` but I didn't.

This PR is to clarify that part of the question and improve the commands.