### PR TITLE
fix args to command

### DIFF
--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -17,7 +17,7 @@ Copy/paste the container related values, so your final YAML should contain the f
 
 ```YAML
 containers:
-  - args:
+  - command:
     - /bin/sh
     - -c
     - echo hello;sleep 3600
@@ -25,7 +25,7 @@ containers:
     imagePullPolicy: IfNotPresent
     name: busybox
     resources: {}
-  - args:
+  - command:
     - /bin/sh
     - -c
     - echo hello;sleep 3600
@@ -82,7 +82,7 @@ initContainer:
 ```YAML
 ...
 initContainers:
-- args:
+- command:
   - /bin/sh
   - -c
   - "wget -O /work-dir/index.html http://neverssl.com/online"
@@ -105,7 +105,7 @@ metadata:
   name: box
 spec:
   initContainers: 
-  - args: 
+  - command: 
     - /bin/sh 
     - -c 
     - "wget -O /work-dir/index.html http://neverssl.com/online"

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -856,7 +856,7 @@ spec:
         run: busybox
     spec:
       containers:
-      - args:
+      - command:
         - /bin/sh
         - -c
         - while true; do echo hello; sleep 10;done
@@ -898,7 +898,7 @@ spec:
         run: busybox
     spec:
       containers:
-      - args:
+      - command:
         - /bin/sh
         - -c
         - echo hello;sleep 30;echo world
@@ -951,7 +951,7 @@ spec:
         run: busybox
     spec:
       containers:
-      - args:
+      - command:
         - /bin/sh
         - -c
         - echo hello;sleep 30;echo world
@@ -1052,7 +1052,7 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - args:
+          - command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster
@@ -1096,7 +1096,7 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - args:
+          - command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/g.state.md
+++ b/g.state.md
@@ -34,7 +34,7 @@ spec:
   dnsPolicy: ClusterFirst
   restartPolicy: Never
   containers:
-  - args:
+  - command:
     - /bin/sh
     - -c
     - sleep 3600
@@ -45,7 +45,7 @@ spec:
     volumeMounts: #
     - name: myvolume #
       mountPath: /etc/foo #
-  - args:
+  - command:
     - /bin/sh
     - -c
     - sleep 3600
@@ -190,7 +190,7 @@ metadata:
   name: busybox
 spec:
   containers:
-  - args:
+  - command:
     - /bin/sh
     - -c
     - sleep 3600


### PR DESCRIPTION
The `args` field is used to provide arguments to the container's default entry point (command), so I thought it would be more accurate to use the `command` field.

If there are no issues, please proceed with the merge.