### PR TITLE
Change namespace required name to one to match other exercises

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -359,7 +359,7 @@ kubernetes.io > Documentation > Concepts > Policies > Limit Ranges (https://kube
 <p>
 
 ```bash
-kubectl create ns one
+kubectl create ns limitrange
 ```
 
 vi 1.yaml
@@ -368,7 +368,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: ns-memory-limit
-  namespace: one
+  namespace: limitrange
 spec:
   limits:
   - max: # max and min define the limit range

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -353,13 +353,13 @@ status: {}
 ## Limit Ranges
 kubernetes.io > Documentation > Concepts > Policies > Limit Ranges (https://kubernetes.io/docs/concepts/policy/limit-range/)
 
-### Create a namespace named limitrange with a LimitRange that limits pod memory to a max of 500Mi and min of 100Mi
+### Create a namespace named one with a LimitRange that limits pod memory to a max of 500Mi and min of 100Mi
 
 <details><summary>show</summary>
 <p>
 
 ```bash
-kubectl create ns limitrange
+kubectl create ns one
 ```
 
 vi 1.yaml
@@ -368,7 +368,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: ns-memory-limit
-  namespace: limitrange
+  namespace: one
 spec:
   limits:
   - max: # max and min define the limit range


### PR DESCRIPTION
in d.configuration.md, one questions asks to create a namespace named limitrange, but the given answer creates a namespace named one. This commit addresses that