### PR TITLE
Fix limit ranges configuration exercise

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -409,7 +409,7 @@ metadata:
   labels:
     run: nginx
   name: nginx
-  namespace: one
+  namespace: limitrange
 spec:
   containers:
   - image: nginx
@@ -417,6 +417,8 @@ spec:
     resources:
       requests:
         memory: "250Mi"
+      limits:
+        memory: "500Mi" # limit has to be specified and be <= limitrange
   dnsPolicy: ClusterFirst
   restartPolicy: Always
 status: {}


### PR DESCRIPTION
Hi,
While practicing I noticed the resource definition in [this exercise](https://github.com/dgkanatsios/CKAD-exercises/blob/main/d.configuration.md#create-an-nginx-pod-that-requests-250mi-of-memory-in-the-limitrange-namespace) seems to have an incorrect namespace. 

It's also necessary to specify the limit for the pod's memory, and this has to be within the range of the LimitRange defined in the namespace

