### PR TITLE
Replaces ns name for ns limitrange

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -390,7 +390,7 @@ kubectl apply -f 1.yaml
 <p>
 
 ```bash
-kubectl describe limitrange ns-memory-limit -n one
+kubectl describe limitrange ns-memory-limit -n limitrange
 ```
 </p>
 </details>
@@ -409,7 +409,7 @@ metadata:
   labels:
     run: nginx
   name: nginx
-  namespace: one
+  namespace: limitrange
 spec:
   containers:
   - image: nginx


### PR DESCRIPTION
In some places there was a reference to namespace "one" but it should be "limitrange".