### PR TITLE
Fix typo in persistent storage tasks

### DIFF
--- a/g.state.md
+++ b/g.state.md
@@ -127,7 +127,7 @@ kubectl get pv
 </p>
 </details>
 
-### Create a PersistentVolumeClaim for this storage class, called 'mypvc', a request of 4Gi and an accessMode of ReadWriteOnce, with the storageClassName of normal, and save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
+### Create a PersistentVolumeClaim for this PersistentVolume, called 'mypvc', a request of 4Gi and an accessMode of ReadWriteOnce, with the storageClassName of normal, and save it on pvc.yaml. Create it on the cluster. Show the PersistentVolumeClaims of the cluster. Show the PersistentVolumes of the cluster
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
Small typo - "this storage class" doesn't really make sense as the storage class is specified later in the sentence, and the task is about creating a PVC for the PV created in the previous task.