### PR TITLE
Fix multi container neverssl exercise

### DIFF
--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -85,7 +85,7 @@ initContainers:
 - args:
   - /bin/sh
   - -c
-  - "wget -O /work-dir/index.html http://neverssl.com/online"
+  - echo "Test" > /work-dir/index.html
   image: busybox
   name: box
   volumeMounts:
@@ -108,7 +108,7 @@ spec:
   - args: 
     - /bin/sh 
     - -c 
-    - "wget -O /work-dir/index.html http://neverssl.com/online"
+    - echo "Test" > /work-dir/index.html
     image: busybox 
     name: box 
     volumeMounts: 

--- a/b.multi_container_pods.md
+++ b/b.multi_container_pods.md
@@ -50,7 +50,7 @@ kubectl delete po busybox
 </p>
 </details>
 
-### Create a pod with an nginx container exposed on port 80. Add a busybox init container which downloads a page using "wget -O /work-dir/index.html http://neverssl.com/online". Make a volume of type emptyDir and mount it in both containers. For the nginx container, mount it on "/usr/share/nginx/html" and for the initcontainer, mount it on "/work-dir". When done, get the IP of the created pod and create a busybox pod and run "wget -O- IP"
+### Create a pod with an nginx container exposed on port 80. Add a busybox init container which downloads a page using 'echo "Test" > /work-dir/index.html'. Make a volume of type emptyDir and mount it in both containers. For the nginx container, mount it on "/usr/share/nginx/html" and for the initcontainer, mount it on "/work-dir". When done, get the IP of the created pod and create a busybox pod and run "wget -O- IP"
 
 <details><summary>show</summary>
 <p>


### PR DESCRIPTION
`neverssl.com` was referenced in one of the exercises but it is not accessible anymore (it can be verified for example with https://www.isitdownrightnow.com/neverssl.com.html).

The issue was already fixed in https://github.com/dgkanatsios/CKAD-exercises/pull/313, but the instructions of the exercise weren't updated at the time. Later in https://github.com/dgkanatsios/CKAD-exercises/pull/315 the changes of https://github.com/dgkanatsios/CKAD-exercises/pull/313 were reverted to a non-working solution of the exercise.

This pull request reverts https://github.com/dgkanatsios/CKAD-exercises/pull/315 so `neverssl.com` isn't used, and updates the exercise instructions to match the solution.