### PR TITLE
Fix the title links in `d.configuration.md` and add the missing title links.

### DIFF
--- a/d.configuration.md
+++ b/d.configuration.md
@@ -5,7 +5,11 @@
 
 [SecurityContext](#securitycontext)
 
-[Requests and Limits](#requests-and-limits)
+[Resource Requests and Limits](#resource-requests-and-limits)
+
+[Limit Ranges](#limit-ranges)
+
+[Resource Quotas](#resource-quotas)
 
 [Secrets](#secrets)
 


### PR DESCRIPTION
Fix the title links in `d.configuration.md` and add the missing title links.