### PR TITLE
Document Ingress resource creation for nginx service

### DIFF
--- a/f.services.md
+++ b/f.services.md
@@ -229,3 +229,60 @@ kubectl run busybox --image=busybox --rm -it --restart=Never --labels=access=gra
 
 </p>
 </details>
+
+### Create an Ingress resource to expose an existing service using HTTP path routing
+You already have:
+- a Deployment nginx
+- a Service nginx exposing port 80
+
+You want to expose it externally using an Ingress rule.
+> Note that in CKAD, you are not required to install an Ingress Controller, but you must know how to define and troubleshoot an Ingress resource and understand how it connects to a Service.
+
+<details><summary>show</summary> <p>
+Verify the service exists:
+  
+```bash
+kubectl get svc nginx
+```
+Expected:
+- Type: ClusterIP
+- Port: 80
+
+If the Deployment and Service do not already exist in your practice environment, you can create them using the following commands:
+```bash
+kubectl create deployment nginx --image=nginx --port=80
+kubectl expose deployment nginx --port=80 --name=nginx
+```
+
+Create an Ingress resource:
+```bash
+vi ingress.yaml
+```
+```bash
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+spec:
+  rules:
+  - host: nginx.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80
+```
+Apply it:
+```bash
+kubectl apply -f ingress.yaml
+```
+
+Verify the Ingress:
+```bash
+kubectl get ingress
+kubectl describe ingress nginx-ingress
+```


### PR DESCRIPTION
Added instructions for creating an Ingress resource to expose an existing nginx service using HTTP path routing.