### PR TITLE
docs: fix stale URLs (gcr.io, k8s.gcr.io), misleading solutions, and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A set of exercises that helped me prepare for the [Certified Kubernetes Application Developer](https://www.cncf.io/certification/ckad/) exam, offered by the Cloud Native Computing Foundation, organized by curriculum domain.
 They may as well serve as learning and practicing with Kubernetes.
 
-Make a mental note of the breadcrumb at the start of the excercise section, to quickly locate the relevant document in kubernetes.io.
+Make a mental note of the breadcrumb at the start of the exercise section, to quickly locate the relevant document in kubernetes.io.
 It is recommended that you read the official documents before attempting exercises below it.
 During the exam, you are only allowed to refer to official documentation from a browser window within the exam VM.
 A Quick Reference box will contain helpful links for each exam exercise as well.
@@ -24,7 +24,7 @@ A Quick Reference box will contain helpful links for each exam exercise as well.
 - [helm](h.helm.md)
 - [Custom Resource Definitions](i.crd.md)
 
-> If your work is related to multiplayer game servers, checkout out [thundernetes, a brand new project to host game servers on Kubernetes](https://github.com/PlayFab/thundernetes)!
+> If your work is related to multiplayer game servers, check out [thundernetes, a brand new project to host game servers on Kubernetes](https://github.com/PlayFab/thundernetes)!
 
 ### Can I PR? There is an error/an alternative way/an extra question/solution I can offer
 

--- a/c.pod_design.md
+++ b/c.pod_design.md
@@ -226,7 +226,9 @@ metadata:
 spec:
   containers:
     - name: cuda-test
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      # k8s.gcr.io was deprecated in 2022 and is read-only. Use registry.k8s.io instead.
+      # See https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-and-geographically-available/
+      image: "registry.k8s.io/cuda-vector-add:v0.1"
   nodeSelector: # add this
     accelerator: nvidia-tesla-p100 # the selection label
 ```
@@ -702,7 +704,7 @@ spec:
 Test if the deployment was successful from within a Pod:
 ```
 # run a wget to the Service my-app-svc
-kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox --command -- wget -qO- my-app-svc
+kubectl run -it --rm --restart=Never busybox --image=busybox --command -- wget -qO- my-app-svc
 
 version-1
 ```
@@ -753,7 +755,7 @@ spec:
 Observe that calling the ip exposed by the service the requests are load balanced across the two versions:
 ```
 # run a busyBox pod that will make a wget call to the service my-app-svc and print out the version of the pod it reached.
-kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox -- /bin/sh -c 'while sleep 1; do wget -qO- my-app-svc; done'
+kubectl run -it --rm --restart=Never busybox --image=busybox -- /bin/sh -c 'while sleep 1; do wget -qO- my-app-svc; done'
 
 version-1
 version-1
@@ -767,7 +769,10 @@ If the v2 is stable, scale it up to 4 replicas and shutdown the v1:
 ```
 kubectl scale --replicas=4 deploy my-app-v2
 kubectl delete deploy my-app-v1
-while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done
+# Note: this `curl` must be executed from inside a Pod in the cluster (see issue #281),
+# not from the host shell, since the Service ClusterIP is only reachable in-cluster.
+# A simple way to do that is to spin up a throwaway curl pod:
+kubectl run curl --image=curlimages/curl --rm -it --restart=Never -- sh -c 'while sleep 0.1; do curl $(kubectl get svc my-app-svc -o jsonpath="{.spec.clusterIP}"); done'
 version-2
 version-2
 version-2

--- a/d.configuration.md
+++ b/d.configuration.md
@@ -388,7 +388,7 @@ kubectl apply -f 1.yaml
 </p>
 </details>
 
-### Describe the namespace limitrange
+### Describe the limitrange in the namespace `limitrange`
 
 <details><summary>show</summary>
 <p>

--- a/f.services.md
+++ b/f.services.md
@@ -46,7 +46,9 @@ or
 
 ```bash
 IP=$(kubectl get svc nginx --template={{.spec.clusterIP}}) # get the IP (something like 10.108.93.130)
-kubectl run busybox --rm --image=busybox -it --restart=Never --env="IP=$IP" -- wget -O- $IP:80 --timeout 2
+# Note: the env var name passed to the pod is intentionally different from the host-side $IP
+# so that the variable inside the container is unambiguous (see issue #231)
+kubectl run busybox --rm --image=busybox -it --restart=Never --env="SVC_IP=$IP" -- sh -c 'wget -O- $SVC_IP:80 --timeout 2'
 # Tip: --timeout is optional, but it helps to get answer more quickly when connection fails (in seconds vs minutes)
 ```
 


### PR DESCRIPTION
Addresses 5 separate student-facing issues in this CKAD practice repo.

**Stale image references**
- `c.pod_design.md`: replace `gcr.io/google-containers/busybox` (read-only since 2022) with the official `busybox` in both canary/blue-green exercise solutions.
- `c.pod_design.md`: replace `k8s.gcr.io/cuda-vector-add` (deprecated in 2022) with `registry.k8s.io/cuda-vector-add` in the GPU exercise.

**Misleading / confusing instructions**
- `c.pod_design.md`: the canary `while … curl …` line must run inside a cluster pod, not on the host shell, because the Service ClusterIP is only reachable in-cluster. Replaced with a `kubectl run curl --image=curlimages/curl` one-liner plus an explanatory comment. (refs #281)
- `d.configuration.md`: rephrased the LimitRange exercise question from the ambiguous "Describe the namespace limitrange" to "Describe the limitrange in the namespace `limitrange`" so it matches the actual `kubectl describe limitrange -n limitrange` solution. (refs #374)
- `f.services.md`: in the wget service-reachability example the host-side $IP and the in-pod $IP were the same variable name. Renamed the in-pod env to $SVC_IP and added a comment. (refs #231)

**Typos**
- `README.md`: `excercise` → `exercise` (refs #342) and `checkout out` → `check out`.

Refs #231, #281, #295, #342, #374.